### PR TITLE
Remove Answer count from Discussions

### DIFF
--- a/qa-include/qa-page-question.php
+++ b/qa-include/qa-page-question.php
@@ -378,11 +378,13 @@
 			$qa_content['a_list']['as'][]=$a_view;
 		}
 	}
-		
-	if ($countfortitle==1)
-		$qa_content['a_list']['title']=qa_lang_html('question/1_answer_title');
-	elseif ($countfortitle>0)
-		$qa_content['a_list']['title']=qa_lang_html_sub('question/x_answers_title', $countfortitle);
+
+	if (in_array($question['basetype'], array('Q', 'Q_HIDDEN'))) {
+		if ($countfortitle==1)
+			$qa_content['a_list']['title']=qa_lang_html('question/1_answer_title');
+		elseif ($countfortitle>0)
+			$qa_content['a_list']['title']=qa_lang_html_sub('question/x_answers_title', $countfortitle);
+	}
 
 	$qa_content['a_list']['title']='<SPAN ID="a_list_title">'.@$qa_content['a_list']['title'].'</SPAN>';
 


### PR DESCRIPTION
- If you have plugins that are changing a post from a question to a discussion and vice versa, you can end up showing answer count for a discussion
- This now checks to see if the basetype of the question is indeed a question, therefore will show answer count
