### PR TITLE
Fix Snow theme feed link when wrapping

### DIFF
--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -877,6 +877,7 @@ font-size:12px;
 .qa-feed {
 	background:#eee url(images/feed-icon-14x14.png) no-repeat 20px center;
 	padding:20px;
+	padding-left:30px;
 	margin:5px 0;
 	border-right:1px solid #ccc;
 	border-bottom:1px solid #ccc;
@@ -884,7 +885,6 @@ font-size:12px;
 .qa-feed-link {
 	font-size:12px;
 	color:#666;
-	padding-left:20px;
 }
 .qa-footer-bottom-group{
 	background:#ddd;	


### PR DESCRIPTION
When the feed link text is too large it is wrapped. The wrapped text used to overlap with the background image. This commit resolves that issue.
