### PR TITLE
Fixed database upgrading bug

### DIFF
--- a/qa-include/qa-db-install.php
+++ b/qa-include/qa-db-install.php
@@ -1362,6 +1362,7 @@
 					break;
 					
 				case 54:
+					qa_db_query_sub("SET FOREIGN_KEY_CHECKS=0;");
 					qa_db_upgrade_query('UNLOCK TABLES');
 				
 					qa_db_upgrade_query(qa_db_create_table_sql('userlevels', array(
@@ -1376,6 +1377,7 @@
 				
 					$locktablesquery.=', ^userlevels WRITE';
 					qa_db_upgrade_query($locktablesquery);
+					qa_db_query_sub("SET FOREIGN_KEY_CHECKS=1;");
 					break;
 					
 			//	Up to here: Version 1.6 beta 1


### PR DESCRIPTION
When upgrading to 1.6 beta 2, this database error occurs:

Question2Answer was unable to perform the installation query below. Please check the user in the config file has CREATE and ALTER permissions: 

CREATE TABLE qa_userlevels (userid INT UNSIGNED NOT NULL, entitytype CHAR(1) CHARACTER SET ascii NOT NULL, entityid INT UNSIGNED NOT NULL, level TINYINT UNSIGNED, UNIQUE userid (userid, entitytype, entityid), KEY entitytype (entitytype, entityid), CONSTRAINT qa_userlevels_ibfk_1 FOREIGN KEY (userid) REFERENCES qa_users(userid) ON DELETE CASCADE) ENGINE=InnoDB CHARSET=utf8 

Error 1005: Can't create table 'qa.qa_userlevels' (errno: 150)

This fix sets foreign_key_checks to 0 before upgrading and resets it back to 1 afterwards. 
