### PR TITLE
Modified display of avatar image in nav bar

### DIFF
--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -339,6 +339,8 @@ input[type="submit"].qa-search-button:hover{
 .qa-logged-in-avatar .qa-avatar-image{
 	max-width: 100%;
 	height: auto;
+	min-width: 24px;
+	min-height: 24px;
 }
 /* end */
 .qa-logged-in-points{


### PR DESCRIPTION
I noticed that when using an avatar (gravatar, in my case) the space needed to render it in the nav bar was not "reserved" in advance. This results in getting at first the page with the nav bar without the avatar and then, once it appears, it moves the rest of the elements to the right. This was only tested on Chrome.
