### PR TITLE
Improved login security by not informing if a user actually exists

### DIFF
--- a/qa-include/qa-lang-users.php
+++ b/qa-include/qa-lang-users.php
@@ -100,7 +100,6 @@
 		'password_none' => 'None. To log in directly, set a password below.',
 		'password_sent' => 'Your new password was emailed to you',
 		'password_to_set' => 'Please set on your account page',
-		'password_wrong' => 'Password not correct',
 		'private_messages_explanation' => 'Allow users to email you (without seeing your address)',
 		'private_messages' => 'Private messages:',
 		'profile_saved' => 'Profile saved',
@@ -133,7 +132,7 @@
 		'unsubscribe_wrong_log_in' => 'Code not correct - please ^1log in^2 to unsubscribe',
 		'unsubscribe' => 'Unsubscribe:',
 		'user_blocked' => '(blocked)',
-		'user_not_found' => 'User not found',
+		'user_or_password_incorrect' => 'User or password incorrect',
 		'website' => 'Website',
 		'x_ago_from_y' => '^1 ago from ^2',
 	);

--- a/qa-include/qa-page-login.php
+++ b/qa-include/qa-page-login.php
@@ -67,7 +67,8 @@
 					$matchusers=qa_db_user_find_by_email($inemailhandle);
 				else
 					$matchusers=qa_db_user_find_by_handle($inemailhandle);
-		
+				
+				$logged_in=false;
 				if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
 					$inuserid=$matchusers[0];
 					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
@@ -77,6 +78,8 @@
 		
 						qa_set_logged_in_user($inuserid, $userinfo['handle'], $inremember ? true : false);
 						
+						$logged_in=true;
+						
 						$topath=qa_get('to');
 						
 						if (isset($topath))
@@ -85,12 +88,11 @@
 							qa_redirect('account');
 						else
 							qa_redirect('');
-		
-					} else
-						$errors['password']=qa_lang('users/password_wrong');
-		
-				} else
-					$errors['emailhandle']=qa_lang('users/user_not_found');
+					}
+				}
+				if (!$logged_in) {
+					$errors['password']=qa_lang('users/user_or_password_incorrect');
+				}
 			}
 				
 		} else


### PR DESCRIPTION
If a user tries to login and receives 2 different errors, one for a not found user and one for a wrong password, then they will know that a user actually exists when they get a wrong password error. That is giving too much unnecessary information.

Also note this change will affect the language file(s).
