### PR TITLE
Added the user id in the user ranking page to ease plugin development.

### DIFF
--- a/qa-include/qa-page-users.php
+++ b/qa-include/qa-page-users.php
@@ -67,6 +67,7 @@
 							$user['avatarblobid'], $user['avatarwidth'], $user['avatarheight'], qa_opt('avatar_users_size'), true)
 					).' '.$usershtml[$user['userid']],
 				'score' => qa_html(number_format($user['points'])),
+				'userid' => $user['userid'],
 			);
 	
 	} else


### PR DESCRIPTION
When processing the user items in a theme/layer everything at hand is a label and a score. The label looks something like this:

``` html
<a href="./user/user1" class="qa-user-link">user1</a>
```

In order to develop a plugin that would, for instance, replace the user1 text displayed in the link with the name of the user or maybe to show the users badges the best approach would be to parse the href link with a regex. Currently, I'm doing it this way:

``` php
preg_match('@<a\s+[^>]*href="[^"]*user/(.*?)"@', $item['label'], $matches)
```

Adding the user id to the result would simplify this process at almost no cost and plugin developers won't have to parse HTML with regex.
