### PR TITLE
Added firing an event on the points update for plugins to listen.

### DIFF
--- a/qa-include/qa-db-points.php
+++ b/qa-include/qa-db-points.php
@@ -188,6 +188,11 @@
 			qa_db_query_raw(str_replace('~', "='".qa_db_escape_string($userid)."'", qa_db_apply_sub($query, array($userid))));
 				// build like this so that a #, $ or ^ character in the $userid (if external integration) isn't substituted
 			
+			qa_report_event('u_points', qa_get_logged_in_userid(), qa_get_logged_in_handle(), qa_cookie_get(), array(
+				'userid' => $userid,
+				'updated_columns' => $keycolumns,
+			));
+			
 			if (qa_db_insert_on_duplicate_inserted())
 				qa_db_userpointscount_update();
 		}


### PR DESCRIPTION
The event might not be as useful as it sounds as it can provide little information without querying the database. Actually, only this information can be quickly passed:

```
[userid] => 8
[updated_columns] => Array (
    [0] => qvoteds
    [1] => upvoteds
    [2] => downvoteds
)
```

Additionally, the reception of the event doesn't necessarily mean a points change but rather only an update being fired. Having the points in the event would mean performing a database query which would reduce performance unnecessarily if there are no listeners of the event (probably there should be a way of registering modules to listen to particular events in the future in order to send the events only to the listeners and if there are any?).

Anyway, if needed, the modules can query the database for the points to check themselves.
