### PR TITLE
Added the user id that received a vote when firing a vote event.

### DIFF
--- a/qa-include/qa-app-votes.php
+++ b/qa-include/qa-app-votes.php
@@ -135,7 +135,7 @@
 			'postid' => $post['postid'],
 			'vote' => $vote,
 			'oldvote' => $oldvote,
-			'post_userid' => $post['postid'],
+			'post_userid' => $post['userid'],
 		));
 	}
 	


### PR DESCRIPTION
Having a reference to the user id might prove very useful in many cases at almost no cost. Ideally, the event would send all post parameters (eg: title, content, etc) but that might decrease performance. Only adding one id is most likely to save a database query or maybe a join from ^posts to ^userpoints or ^users.

Example: If I wanted to show a message when a user reaches 100 upvotes I would have to get the postid from the params array, select the post from ^post based on the postid and then join ^userpoints to get the upvoteds fields. This would save selecting on the ^posts table and allow a direct (scalar) query to the ^userpoints table.
