### PR TITLE
Added a function that returns the currently existent indexes for a table

### DIFF
--- a/qa-include/qa-db.php
+++ b/qa-include/qa-db.php
@@ -402,6 +402,18 @@
 	}
 	
 	
+	function qa_db_get_indexes_from_table($table)
+/*
+	Return an array of the current indexes for the given table
+*/
+	{
+		$results=qa_db_read_all_assoc(qa_db_query_raw('SHOW INDEXES FROM ' . $table));
+		foreach($results as $index => $result)
+			$results[$index]['Table'] = strtolower($result['Table']); 
+		return $results;
+	}
+	
+	
 	function qa_db_list_tables()
 /*
 	Return an array of the names of all tables in the Q2A database


### PR DESCRIPTION
I just added a function that returns index data. Useful when releasing a new plugin version and new indexes should be created and/or old indexes removed. Output looks like this:

```
Array
(
    [0] => Array
        (
            [Table] => qa_my_plugin_table
            [Non_unique] => 1
            [Key_name] => my_index_idx
            [Seq_in_index] => 1
            [Column_name] => id
            [Collation] => A
            [Cardinality] => 1
            [Sub_part] => 
            [Packed] => 
            [Null] => 
            [Index_type] => BTREE
            [Comment] => 
        )

    [1] => Array
        (
            [Table] => qa_my_plugin_table
            [Non_unique] => 1
            [Key_name] => my_index_idx
            [Seq_in_index] => 2
            [Column_name] => id
            [Collation] => A
            [Cardinality] => 1
            [Sub_part] => 
            [Packed] => 
            [Null] => 
            [Index_type] => BTREE
            [Comment] => 
        )
)
```
