### PR TITLE
Added a handy method to add columns in rankings from layers.

### DIFF
--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -1279,25 +1279,30 @@
 					$this->ranking_score($item, $class);
 			}
 		}
+
+		function ranking_cell($class, $class_suffix, $content)
+		{
+			$this->output('<td class="'.$class.'-'.$class_suffix.'">'.$content.'</td>');
+		}
 		
 		function ranking_spacer($class)
 		{
-			$this->output('<td class="'.$class.'-spacer">&nbsp;</td>');
+			$this->ranking_cell($class, 'spacer', '&nbsp;');
 		}
 		
 		function ranking_count($item, $class)
 		{
-			$this->output('<td class="'.$class.'-count">'.$item['count'].' &#215;'.'</td>');
+			$this->ranking_cell($class, 'count', $item['count'].' &#215;');
 		}
 		
 		function ranking_label($item, $class)
 		{
-			$this->output('<td class="'.$class.'-label">'.$item['label'].'</td>');
+			$this->ranking_cell($class, 'label', $item['label']);
 		}
 		
 		function ranking_score($item, $class)
 		{
-			$this->output('<td class="'.$class.'-score">'.$item['score'].'</td>');
+			$this->ranking_cell($class, 'score', $item['score']);
 		}
 		
 		function message_list_and_form($list)


### PR DESCRIPTION
Me again. I've added a method that provides an easy way to add columns to rankings allowing the user to keep compatibility. Easier to see than to explain.

Best way I could think to do this in 1.6.2:

``` php
public function ranking_item($item, $class, $spacer) {
    qa_html_theme_base::ranking_item($item, $class, $spacer);
    $this->ranking_custom_column($item, $class);
}

public function ranking_custom_column($item, $class) {
    $this->output('<td class="'.$class.'-mysuffix">'.$this->process($item).'</td>');
}
```

Disadvantage: I'm creating the whole cell. What if in the future you remove td tags and add divs (although inappropriate in this case)? Or a less radical change, some additional attributes are added to the td and my layer would have to be updated too.

Proposed way:

``` php
public function ranking_item($item, $class, $spacer) {
    qa_html_theme_base::ranking_item($item, $class, $spacer);
    $this->ranking_custom_column($item, $class);
}

public function ranking_custom_column($item, $class) {
    qa_html_theme_base::ranking_cell($class, 'mysuffix', $this->process($item));
}
```

Basically, I'm just sending the data I need: cell format and cell content. And I let the framework do the work for me. Even internally the framework reuses the function so there is additional code reuse in the framework itself. Also this won't break previously created plugins as the interface is exactly the same
