### PR TITLE
Fixed an issue in which all admin menu items take 3 lines.

### DIFF
--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -584,8 +584,18 @@ div.header-banner{
 	-ms-transition:all ease-in-out 0.2s;
 	transition:all ease-in-out 0.2s;
 }
-.qa-nav-sub-admin-moderate {
-	clear:left;
+.qa-nav-sub-admin-moderate,
+.qa-nav-sub-admin-flagged,
+.qa-nav-sub-admin-hidden{
+	background-color:#DDD;
+	border-radius:2px;
+	border:1px solid #999;
+	margin:0 2px;
+}
+.qa-nav-sub-admin-moderate .qa-nav-sub-link,
+.qa-nav-sub-admin-flagged .qa-nav-sub-link,
+.qa-nav-sub-admin-hidden .qa-nav-sub-link{
+	margin:0 0px;
 }
 /*-- end main + sub navigation css --*/
 /*-- content and widgets --*/


### PR DESCRIPTION
It seems whenever the length of the items is too long, the items span into 3 lines. This is due to a `clear: left` taking place for the last three elements. So, if all the elements before them happen to span 2 lines then the `clear: left` adds an additional one.

I think the intention is to somehow make those 3 elements stand out. So I added a box around them but made sure the `clear: left` is gone so that the elements take the space they need and no more than that.

Just mentioning @q2amarket to take a look at it too and evaluate a different approach if needed.
