### PR TITLE
Denied URL access to disabled pages in the Pages section

### DIFF
--- a/qa-include/qa-page-activity.php
+++ b/qa-include/qa-page-activity.php
@@ -28,7 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
-
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_activity')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 	require_once QA_INCLUDE_DIR.'qa-app-format.php';

--- a/qa-include/qa-page-categories.php
+++ b/qa-include/qa-page-categories.php
@@ -28,6 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_categories')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 	require_once QA_INCLUDE_DIR.'qa-app-format.php';

--- a/qa-include/qa-page-hot.php
+++ b/qa-include/qa-page-hot.php
@@ -28,6 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_hot')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 	require_once QA_INCLUDE_DIR.'qa-app-q-list.php';

--- a/qa-include/qa-page-questions.php
+++ b/qa-include/qa-page-questions.php
@@ -28,6 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_questions')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 	require_once QA_INCLUDE_DIR.'qa-app-format.php';

--- a/qa-include/qa-page-tags.php
+++ b/qa-include/qa-page-tags.php
@@ -28,6 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_tags')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';
 	require_once QA_INCLUDE_DIR.'qa-app-format.php';

--- a/qa-include/qa-page-users.php
+++ b/qa-include/qa-page-users.php
@@ -28,6 +28,11 @@
 		header('Location: ../');
 		exit;
 	}
+	
+	// Do not grant access to this section if it has been disabled
+	if (!qa_opt('nav_users')) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
 
 	require_once QA_INCLUDE_DIR.'qa-db-users.php';
 	require_once QA_INCLUDE_DIR.'qa-db-selects.php';


### PR DESCRIPTION
_After messing up with the branches and creating a pull request to the q2a/master branch I'm recreating the pull request from scratch. Let's see if this time I do it right :)_

I noticed that when disabling sections in the _Admin > Pages_ section all you do is just hiding the link. However, these pages can still be accessed by URL. A clear example of this situation is the [Q2A](http://www.question2answer.org) site in which the _Categories_ section is disables but can still be accessed by http://www.question2answer.org/qa/categories.

As a user, I feel this is not the right behavior. If I disable a page I would expect it not be accessed by any means. Hiding it from the menu doesn't make much difference. This is also related to a security flaw I mentioned in a patch-3 (ac2fee937355a98ffc80b948e54d6514360cdd68) in which failed login attempts let the person/bot on the other site see if the user actually existed. This relates to this issue because there is no way to fully hide the _Users_ page and that is giving away information to bots.

Hopefully, this patch would allow users to really hide those pages. Note that _Ask_ page should not be blocked because it can be accessed by other means (and it wouldn't make any sense to disable it, btw).
