### PR TITLE
Added the raw user attributes to the blocked and special users pages

### DIFF
--- a/qa-include/qa-page-users-blocked.php
+++ b/qa-include/qa-page-users-blocked.php
@@ -75,6 +75,7 @@
 		$qa_content['ranking']['items'][]=array(
 			'label' => $usershtml[$user['userid']],
 			'score' => qa_html(qa_user_level_string($user['level'])),
+			'raw' => $user,
 		);
 	}
 

--- a/qa-include/qa-page-users-special.php
+++ b/qa-include/qa-page-users-special.php
@@ -75,6 +75,7 @@
 		$qa_content['ranking']['items'][]=array(
 			'label' => $usershtml[$user['userid']],
 			'score' => qa_html(qa_user_level_string($user['level'])),
+			'raw' => $user,
 		);
 	}
 


### PR DESCRIPTION
Based on a previous [pull request](https://github.com/q2a/question2answer/pull/15/files) I guess no one realized there were 3 user list pages :) That means the special and blocked user lists where throwing notices.

This pull request corrects that missing field in both pages. Hopefully, it could be rolled into 1.6.4 as it is a very minimal correction. Thanks.
