### PR TITLE
Improvements for the Snow theme profile section

### DIFF
--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -2631,12 +2631,18 @@ a.qa-browse-cat-link:visited {
 .qa-template-user .qa-part-form-profile {
 	float: left;
 	width: 50%;
-	min-height: 630px;
 	padding: 0 1% 0 0;
 	border-right: 1px solid #ddd;
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
+}
+
+.qa-template-user .qa-part-form-profile,
+.qa-template-user .qa-part-form-activity,
+.qa-template-user .qa-part-message-list {
+	padding-bottom: 100%;
+	margin-bottom: -100%;
 }
 
 .qa-template-user .qa-part-message-list .qa-form-tall-text,


### PR DESCRIPTION
It seems the theme is not able to handle new sections (parts, actually) in the profile section. It is easily explained with some images.

Here is the profile section when a new part fits on the right column: [Link](http://postimg.org/image/auaic9hrx/)
Here is the profile section when a new part doesn't fit on the right column: [Link](http://postimg.org/image/slm4qpx6l/)
Here is the profile section after the fix: [Link](http://postimg.org/image/bmd6bglz1/)

This design is flexible enough for a developer to be able to choose in which column to add a new section by just changing the `float` and `clear` to `right` or `left`.

That's for the first commit. Now, as you can see, the line in the middle has a fixed height. In order for it to grow I've added the second commit. That's the only way I could find that didn't require major HTML changes. Feel free to cherry-pick.

Probably, it good be a good idea to include these changes now as I've seen there have been lots of changes to the theme recently.

I almost forget to mention @q2amarket.
