### PR TITLE
Improvements to the update feature

### DIFF
--- a/qa-content/qa-admin.js
+++ b/qa-content/qa-admin.js
@@ -134,9 +134,9 @@ function qa_admin_click(target)
 	return false;
 }
 
-function qa_version_check(uri, versionkey, version, urikey, elem)
+function qa_version_check(uri, version, elem)
 {
-	var params={uri:uri, versionkey:versionkey, version:version, urikey:urikey};
+	var params={uri:uri, version:version};
 
 	qa_ajax_post('version', params,
 		function (lines) {

--- a/qa-include/qa-ajax-version.php
+++ b/qa-include/qa-ajax-version.php
@@ -24,54 +24,35 @@
 	More about this license: http://www.question2answer.org/license.php
 */
 
-	require_once QA_INCLUDE_DIR.'qa-app-admin.php';
+	require_once QA_INCLUDE_DIR . 'qa-app-admin.php';
 
-
-	$uri=qa_post_text('uri');
-	$versionkey=qa_post_text('versionkey');
-	$urikey=qa_post_text('urikey');
-	$version=qa_post_text('version');
-
-	$metadata=qa_addon_metadata(qa_retrieve_url($uri), array(
-		'version' => $versionkey,
-		'uri' => $urikey,
-
-		// these two elements are only present for plugins, not themes, so we can hard code them here
-		'min_q2a' => 'Plugin Minimum Question2Answer Version',
-		'min_php' => 'Plugin Minimum PHP Version',
-	));
-
-	if (strlen(@$metadata['version'])) {
-		if (strcmp($metadata['version'], $version)) {
-			if (qa_qa_version_below(@$metadata['min_q2a']))
-				$response=strtr(qa_lang_html('admin/version_requires_q2a'), array(
-					'^1' => qa_html('v'.$metadata['version']),
-					'^2' => qa_html($metadata['min_q2a']),
+	$uri = qa_post_text('uri');
+	$version = qa_post_text('version');
+	$metadata = qa_addon_metadata(qa_retrieve_url($uri));
+	
+	if (isset($metadata['version'])) {
+		if ($metadata['version'] !== $version) {
+			if (isset($metadata['q2a_version']) && qa_qa_version_below($metadata['q2a_version']))
+				$response = strtr(qa_lang_html('admin/version_requires_q2a'), array(
+					'^1' => qa_html('v' . $metadata['version']),
+					'^2' => qa_html($metadata['q2a_version']),
 				));
-
-			elseif (qa_php_version_below(@$metadata['min_php']))
-				$response=strtr(qa_lang_html('admin/version_requires_php'), array(
-					'^1' => qa_html('v'.$metadata['version']),
-					'^2' => qa_html($metadata['min_php']),
+			elseif (isset($metadata['php_version']) && qa_php_version_below($metadata['php_version']))
+				$response = strtr(qa_lang_html('admin/version_requires_php'), array(
+					'^1' => qa_html('v' . $metadata['version']),
+					'^2' => qa_html($metadata['php_version']),
 				));
-
 			else {
-				$response=qa_lang_html_sub('admin/version_get_x', qa_html('v'.$metadata['version']));
-
-				if (strlen(@$metadata['uri']))
-					$response='<a href="'.qa_html($metadata['uri']).'" style="color:#d00;">'.$response.'</a>';
+				$response = qa_lang_html_sub('admin/version_get_x', qa_html('v' . $metadata['version']));
+				if (isset($metadata['uri']))
+					$response = sprintf('<a href="%s" style="color:#d00;">%s</a>', qa_html($metadata['uri']), $response);
 			}
-
 		} else
-			$response=qa_lang_html('admin/version_latest');
-
+			$response = qa_lang_html('admin/version_latest');
 	} else
-		$response=qa_lang_html('admin/version_latest_unknown');
-
+		$response = qa_lang_html('admin/version_latest_unknown');
 
 	echo "QA_AJAX_RESPONSE\n1\n".$response;
-
-
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-include/qa-app-admin.php
+++ b/qa-include/qa-app-admin.php
@@ -574,14 +574,14 @@
 	}
 
 	/**
-	 * @deprecated Deprecated since Q2A v1.8. Use qa_addon_metadata($contents, $fields) instead
+	 * @deprecated Deprecated since Q2A v1.8. Use qa_addon_metadata($contents) instead
 	 */
 	function qa_admin_addon_metadata($contents, $fields)
 /*
 	Retrieve metadata information from the $contents of a qa-theme.php or qa-plugin.php file, mapping via $fields
 */
 	{
-		return qa_addon_metadata($contents, $fields);
+		return qa_addon_metadata($contents);
 	}
 
 

--- a/qa-include/qa-page-admin-default.php
+++ b/qa-include/qa-page-admin-default.php
@@ -991,46 +991,38 @@
 
 					$contents=file_get_contents(QA_THEME_DIR.$value.'/qa-styles.css');
 
-					$metadata=qa_addon_metadata($contents, array(
-						'uri' => 'Theme URI',
-						'version' => 'Theme Version',
-						'date' => 'Theme Date',
-						'author' => 'Theme Author',
-						'author_uri' => 'Theme Author URI',
-						'license' => 'Theme License',
-						'update' => 'Theme Update Check URI',
-					));
+					$metadata=qa_addon_metadata($contents);
 
-					if (strlen(@$metadata['version']))
+					if (isset($metadata['version']))
 						$namehtml='v'.qa_html($metadata['version']);
 					else
 						$namehtml='';
 
-					if (strlen(@$metadata['uri'])) {
-						if (!strlen($namehtml))
+					if (isset($metadata['uri'])) {
+						if (empty($namehtml))
 							$namehtml=qa_html($value);
 
 						$namehtml='<a href="'.qa_html($metadata['uri']).'">'.$namehtml.'</a>';
 					}
 
-					if (strlen(@$metadata['author'])) {
+					if (isset($metadata['author'])) {
 						$authorhtml=qa_html($metadata['author']);
 
-						if (strlen(@$metadata['author_uri']))
+						if (isset($metadata['author_uri']))
 							$authorhtml='<a href="'.qa_html($metadata['author_uri']).'">'.$authorhtml.'</a>';
 
 						$authorhtml=qa_lang_html_sub('main/by_x', $authorhtml);
 
 					} else
 						$authorhtml='';
-
-					if (strlen(@$metadata['version']) && strlen(@$metadata['update'])) {
+					
+					if (isset($metadata['version']) && isset($metadata['update_uri'])) {
 						$elementid='version_check_'.$optionname;
 
 						$updatehtml='(<span id="'.$elementid.'">...</span>)';
 
 						$qa_content['script_onloads'][]=array(
-							"qa_version_check(".qa_js($metadata['update']).", 'Theme Version', ".qa_js($metadata['version'], true).", 'Theme URI', ".qa_js($elementid).");"
+							"qa_version_check(".qa_js($metadata['update_uri']).", ".qa_js($metadata['version'], true).", ".qa_js($elementid).");"
 						);
 
 					} else

--- a/qa-include/qa-page-admin-plugins.php
+++ b/qa-include/qa-page-admin-plugins.php
@@ -109,37 +109,24 @@
 
 			$contents=file_get_contents($pluginfile);
 
-			$metadata=qa_addon_metadata($contents, array(
-				'name' => 'Plugin Name',
-				'uri' => 'Plugin URI',
-				'description' => 'Plugin Description',
-				'version' => 'Plugin Version',
-				'date' => 'Plugin Date',
-				'author' => 'Plugin Author',
-				'author_uri' => 'Plugin Author URI',
-				'license' => 'Plugin License',
-				'min_q2a' => 'Plugin Minimum Question2Answer Version',
-				'min_php' => 'Plugin Minimum PHP Version',
-				'update' => 'Plugin Update Check URI',
-			));
+			$metadata=qa_addon_metadata($contents);
 
-			if (strlen(@$metadata['name']))
+			if (isset($metadata['name']))
 				$namehtml=qa_html($metadata['name']);
 			else
 				$namehtml=qa_lang_html('admin/unnamed_plugin');
-
-			if (strlen(@$metadata['uri']))
+			if (isset($metadata['uri']))
 				$namehtml='<a href="'.qa_html($metadata['uri']).'">'.$namehtml.'</a>';
 
 			$namehtml='<b>'.$namehtml.'</b>';
 
-			if (strlen(@$metadata['version']))
+			if (isset($metadata['version']))
 				$namehtml.=' v'.qa_html($metadata['version']);
 
-			if (strlen(@$metadata['author'])) {
+			if (isset($metadata['author'])) {
 				$authorhtml=qa_html($metadata['author']);
 
-				if (strlen(@$metadata['author_uri']))
+				if (isset($metadata['author_uri']))
 					$authorhtml='<a href="'.qa_html($metadata['author_uri']).'">'.$authorhtml.'</a>';
 
 				$authorhtml=qa_lang_html_sub('main/by_x', $authorhtml);
@@ -147,19 +134,19 @@
 			} else
 				$authorhtml='';
 
-			if (strlen(@$metadata['version']) && strlen(@$metadata['update'])) {
+			if (isset($metadata['version']) && isset($metadata['update_uri'])) {
 				$elementid='version_check_'.md5($plugindirectory);
 
 				$updatehtml='(<span id="'.$elementid.'">...</span>)';
 
 				$qa_content['script_onloads'][]=array(
-					"qa_version_check(".qa_js($metadata['update']).", 'Plugin Version', ".qa_js($metadata['version'], true).", 'Plugin URI', ".qa_js($elementid).");"
+					"qa_version_check(".qa_js($metadata['update_uri']).", ".qa_js($metadata['version'], true).", ".qa_js($elementid).");"
 				);
 
 			} else
 				$updatehtml='';
 
-			if (strlen(@$metadata['description']))
+			if (isset($metadata['description']))
 				$deschtml=qa_html($metadata['description']);
 			else
 				$deschtml='';
@@ -171,13 +158,13 @@
 			$pluginhtml=$namehtml.' '.$authorhtml.' '.$updatehtml.'<br>'.$deschtml.(strlen($deschtml) ? '<br>' : '').
 				'<small style="color:#666">'.qa_html($plugindirectory).'</small>';
 
-			if (qa_qa_version_below(@$metadata['min_q2a']))
+			if (isset($metadata['q2a_version']) && qa_php_version_below($metadata['q2a_version']))
 				$pluginhtml='<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
-					qa_lang_html_sub('admin/requires_q2a_version', qa_html($metadata['min_q2a'])).'</span>';
+					qa_lang_html_sub('admin/requires_q2a_version', qa_html($metadata['q2a_version'])).'</span>';
 
-			elseif (qa_php_version_below(@$metadata['min_php']))
+			elseif (isset($metadata['php_version']) && qa_php_version_below($metadata['php_version']))
 				$pluginhtml='<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
-					qa_lang_html_sub('admin/requires_php_version', qa_html($metadata['min_php'])).'</span>';
+					qa_lang_html_sub('admin/requires_php_version', qa_html($metadata['php_version'])).'</span>';
 
 			$qa_content['form_plugin_'.$pluginindex]=array(
 				'tags' => 'id="'.qa_html($hash).'"',

--- a/qa-plugin/basic-adsense/qa-plugin.php
+++ b/qa-plugin/basic-adsense/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: Basic AdSense
-	Plugin URI:
-	Plugin Description: Provides a basic widget for displaying Google AdSense ads
-	Plugin Version: 1.0
-	Plugin Date: 2011-03-27
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.4
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: Basic AdSense
+	Plugin URI [uri]: 
+	Plugin Description [description]: Provides a basic widget for displaying Google AdSense ads
+	Plugin Version [version]: 1.0
+	Plugin Date [date]: 2011-03-27
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [version]: 1.4
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/event-logger/qa-plugin.php
+++ b/qa-plugin/event-logger/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: Event Logger
-	Plugin URI:
-	Plugin Description: Stores a record of user activity in the database and/or log files
-	Plugin Version: 1.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: Event Logger
+	Plugin URI [uri]: 
+	Plugin Description [description]: Stores a record of user activity in the database and/or log files
+	Plugin Version [version]: 1.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [version]: 1.5
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/example-page/qa-plugin.php
+++ b/qa-plugin/example-page/qa-plugin.php
@@ -25,17 +25,19 @@
 */
 
 /*
-	Plugin Name: Example Page
-	Plugin URI:
-	Plugin Description: Example of page plugin
-	Plugin Version: 1.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
-*/
+	[metadata]
+	Plugin Name	[name]: Example Page
+	Plugin URI [uri]: 
+	Plugin Description [description]: Example of page plugin
+	Plugin Version [version]: 1.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Update Check URI	[update_uri]: 
+	[/metadata]
+ */
 
 
 	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser

--- a/qa-plugin/facebook-login/qa-plugin.php
+++ b/qa-plugin/facebook-login/qa-plugin.php
@@ -25,17 +25,19 @@
 */
 
 /*
-	Plugin Name: Facebook Login
-	Plugin URI:
-	Plugin Description: Allows users to log in via Facebook
-	Plugin Version: 1.1.5
-	Plugin Date: 2012-09-13
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Minimum PHP Version: 5
-	Plugin Update Check URI:
+    [metadata]
+	Plugin Name [name]: Facebook Login
+	Plugin URI [uri]: 
+	Plugin Description [description]: Allows users to log in via Facebook
+	Plugin Version [version]: 1.1.5
+	Plugin Date [date]: 2012-09-13
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Minimum PHP Version [php_version]: 5
+	Plugin Update Check URI [update_uri]:
+    [/metadata]
 */
 
 

--- a/qa-plugin/mouseover-layer/qa-plugin.php
+++ b/qa-plugin/mouseover-layer/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: Mouseover Layer
-	Plugin URI:
-	Plugin Description: Shows question content on mouse over in question lists
-	Plugin Version: 1.0.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: Mouseover Layer
+	Plugin URI [uri]: 
+	Plugin Description [description]: Shows question content on mouse over in question lists
+	Plugin Version [version]: 1.0.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/opensearch-support/qa-plugin.php
+++ b/qa-plugin/opensearch-support/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: OpenSearch Support
-	Plugin URI:
-	Plugin Description: Allows OpenSearch clients to search Q2A site directly
-	Plugin Version: 1.0
-	Plugin Date: 2012-08-21
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: OpenSearch Support
+	Plugin URI [uri]: 
+	Plugin Description [description]: Allows OpenSearch clients to search Q2A site directly
+	Plugin Version [version]: 1.0
+	Plugin Date [date]: 2012-08-21
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/recaptcha-captcha/qa-plugin.php
+++ b/qa-plugin/recaptcha-captcha/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: reCAPTCHA
-	Plugin URI:
-	Plugin Description: Provides support for reCAPTCHA captchas
-	Plugin Version: 1.0
-	Plugin Date: 2011-11-17
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: reCAPTCHA
+	Plugin URI [uri]: 
+	Plugin Description [description]: Provides support for reCAPTCHA captchas
+	Plugin Version [version]: 1.0
+	Plugin Date [date]: 2011-11-17
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Update Check URI [update_uri]:
+	[/metadata]
 */
 
 

--- a/qa-plugin/tag-cloud-widget/qa-plugin.php
+++ b/qa-plugin/tag-cloud-widget/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: Tag Cloud Widget
-	Plugin URI:
-	Plugin Description: Provides a list of tags with size indicating popularity
-	Plugin Version: 1.0.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.4
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: Tag Cloud Widget
+	Plugin URI [uri]: 
+	Plugin Description [description]: Provides a list of tags with size indicating popularity
+	Plugin Version [version]: 1.0.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.4
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/wysiwyg-editor/qa-plugin.php
+++ b/qa-plugin/wysiwyg-editor/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: WYSIWYG Editor
-	Plugin URI:
-	Plugin Description: Wrapper for CKEditor WYSIWYG rich text editor
-	Plugin Version: 1.1.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.3
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: WYSIWYG Editor
+	Plugin URI [uri]: 
+	Plugin Description [description]: Wrapper for CKEditor WYSIWYG rich text editor
+	Plugin Version [version]: 1.1.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.3
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-plugin/xml-sitemap/qa-plugin.php
+++ b/qa-plugin/xml-sitemap/qa-plugin.php
@@ -25,16 +25,18 @@
 */
 
 /*
-	Plugin Name: XML Sitemap
-	Plugin URI:
-	Plugin Description: Generates sitemap.xml file for submission to search engines
-	Plugin Version: 1.1.1
-	Plugin Date: 2011-12-06
-	Plugin Author: Question2Answer
-	Plugin Author URI: http://www.question2answer.org/
-	Plugin License: GPLv2
-	Plugin Minimum Question2Answer Version: 1.5
-	Plugin Update Check URI:
+	[metadata]
+	Plugin Name [name]: XML Sitemap
+	Plugin URI [uri]: 
+	Plugin Description [description]: Generates sitemap.xml file for submission to search engines
+	Plugin Version [version]: 1.1.1
+	Plugin Date [date]: 2011-12-06
+	Plugin Author [author]: Question2Answer
+	Plugin Author URI [author_uri]: http://www.question2answer.org/
+	Plugin License [license]: GPLv2
+	Plugin Minimum Question2Answer Version [q2a_version]: 1.5
+	Plugin Update Check URI [update_uri]: 
+	[/metadata]
 */
 
 

--- a/qa-theme/Candy/qa-styles.css
+++ b/qa-theme/Candy/qa-styles.css
@@ -23,13 +23,15 @@
 */
 
 /*
-	Theme URI:
-	Theme Version: 1.5
-	Theme Date: 2012-09-11
-	Theme Author: Question2Answer
-	Theme Author URI: http://www.question2answer.org/
-	Theme License: GPLv2
-	Theme Update Check URI:
+    [metadata]
+	Theme URI [uri]: 
+	Theme Version [version]: 1.5
+	Theme Date [date]: 2012-09-11
+	Theme Author [author]: Question2Answer
+	Theme Author URI [author_uri]: http://www.question2answer.org/
+	Theme License [license]: GPLv2
+	Theme Update Check URI [update_uri]: 
+    [/metadata]
 */
 
 

--- a/qa-theme/Classic/qa-styles.css
+++ b/qa-theme/Classic/qa-styles.css
@@ -23,13 +23,15 @@
 */
 
 /*
-	Theme URI:
-	Theme Version: 1.5
-	Theme Date: 2012-09-11
-	Theme Author: Question2Answer
-	Theme Author URI: http://www.question2answer.org/
-	Theme License: GPLv2
-	Theme Update Check URI:
+    [metadata]
+	Theme URI [uri]: 
+	Theme Version [version]: 1.5
+	Theme Date [date]: 2012-09-11
+	Theme Author [author]: Question2Answer
+	Theme Author URI [author_uri]: http://www.question2answer.org/
+	Theme License [license]: GPLv2
+	Theme Update Check URI [update_uri]: 
+    [/metadata]
 */
 
 

--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -1,11 +1,13 @@
 /*
-	Theme Name: Snow
-	Theme URI:
-	Theme Version: 1.3
-	Theme Date: 2013-11-13
-	Theme Author: Q2A Market
-	Theme Author URI: http://www.q2amarket.com/
-	Theme License: GPLv2
+    [metadata]
+	Theme Name [name]: Snow
+	Theme URI [uri]: 
+	Theme Version [version]: 1.3
+	Theme Date [date]: 2013-11-13
+	Theme Author [author]: Q2A Market
+	Theme Author URI [author_uri]: http://www.q2amarket.com/
+	Theme License [license]: GPLv2
+    [/metadata]
 */
 
 


### PR DESCRIPTION
I've created a few commits regarding the update feature (except the first one which is trivial but not less necessary).

48af2fb: This commit basically removes duplicated code
e9b604f: This commit is an upgrade to the previous one. It modifies how `qa_admin_addon_metadata` is extracting data, removes the replacement of spaces with `\s*`, removes the requested fields and absolutely forgets about having to parse things like `Plugin Minimum Question2Answer Version`.

The parsing process first looks for a given tag (eg: `[metadata]`) and fetches all information from it. This has the advantage that if the file contains a few not found keys then instead to having to parse the whole file to find out the keys are not there that would only happen twice. Secondly, returning just the matched `[metadata]` tag reduces the whole matching domain letting future searches run faster.

The matching logic for each value is replaced by using inner tags such as `[php_version]`. Each of those inner tags will be the keys returned. That means that instead of asking the function under what key you want to find a given field you will get all keys at once and the keys will be defined by whatever is between square brackets the file qa-plugin.php  or theme file itself. Of course, corresponding values will also be returned making sure whitespace (spaces and tabs) trimmed values are not empty. If they are, they won't be included in the array.
