### PR TITLE
Fixed an issue in which the avatar image falls down the qa-login-bar

### DIFF
--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -406,13 +406,6 @@ input[type="submit"].qa-search-button:hover {
 	width: 24px;
 }
 
-.qa-logged-in-avatar .qa-avatar-image {
-	max-width: 100%;
-	height: auto;
-	min-width: 24px; /* pull request */
-	min-height: 24px; /* pull request */
-}
-
 /* end */
 .qa-logged-in-points {
 	float: left;


### PR DESCRIPTION
I've provided a fix for an issue in this pull request: https://github.com/q2a/question2answer/pull/13

However, that created another issue that is explained here: http://www.question2answer.org/qa/32810. It seems images exceed the 24px size.

So I thought that a better approach would be just to rely on the sizes provided by the core and not change anything in the CSS. I tested this on Chrome 35, IE 11 and FF 29 and it seems to be working fine.

Tagging @q2amarket in case he's still interested in maintaining Snow theme 1.3.
