### PR TITLE
Added checks and error displays when exceeding post_max_size and upload_max_filesize limits

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1018,6 +1018,33 @@
 	}
 
 
+	function qa_is_post_max_size_limit_exceeded()
+/*
+	Checks whether an HTTP request has exceeded the post_max_size PHP variable. This happens whenever an HTTP request
+	is too big to be properly processed by PHP, usually because there is an attachment in the HTTP request. A warning
+	is added to the server's log displaying the size of the file that triggered this situation. It is important to note
+	that whenever this happens the $_POST and $_FILES superglobals are empty.
+*/
+	{
+		if (in_array($_SERVER['REQUEST_METHOD'], array('POST', 'PUT')) && empty($_POST) && empty($_FILES)) {
+			$postmaxsize = ini_get('post_max_size');  // Gets the current post_max_size configuration
+			$unit = substr($postmaxsize, -1);
+			if (!is_numeric($unit)) {
+				$postmaxsize = substr($postmaxsize, 0, -1);
+			}
+			switch (strtoupper($unit)) {  // Gets an integer value that can be compared against the size of the HTTP request
+				case 'G':
+					$postmaxsize *= 1024;
+				case 'M':
+					$postmaxsize *= 1024;
+				case 'K':
+					$postmaxsize *= 1024;
+			}
+			return $_SERVER['CONTENT_LENGTH'] > $postmaxsize;
+		}
+	}
+
+
 	function qa_is_mobile_probably()
 /*
 	Return true if it appears that the page request is coming from a mobile client rather than a desktop/laptop web browser

--- a/qa-include/qa-lang-main.php
+++ b/qa-include/qa-lang-main.php
@@ -81,6 +81,7 @@
 		'date_year_digits' => 4, // 2 or 4
 		'edited' => 'edited',
 		'field_required' => 'Please enter something in this field',
+		'file_upload_limit_exceeded' => 'The size of the file exceeds the server\'s limits',
 		'general_error' => 'A server error occurred - please try again.',
 		'hidden' => 'hidden',
 		'highest_users' => 'Top scoring users',

--- a/qa-include/qa-page-account.php
+++ b/qa-include/qa-page-account.php
@@ -65,138 +65,146 @@
 
 //	Process profile if saved
 
-	if (qa_clicked('dosaveprofile') && !$isblocked) {
-		require_once QA_INCLUDE_DIR.'qa-app-users-edit.php';
+	// If the post_max_size is exceeded then the $_POST array is empty so no field processing can be done
+	if (qa_is_post_max_size_limit_exceeded())
+		$errors['avatar'] = qa_lang('main/file_upload_limit_exceeded');
+	else {
+		if (qa_clicked('dosaveprofile') && !$isblocked) {
+			require_once QA_INCLUDE_DIR . 'qa-app-users-edit.php';
 
-		$inhandle=$changehandle ? qa_post_text('handle') : $useraccount['handle'];
-		$inemail=qa_post_text('email');
-		$inmessages=qa_post_text('messages');
-		$inwallposts=qa_post_text('wall');
-		$inmailings=qa_post_text('mailings');
-		$inavatar=qa_post_text('avatar');
+			$inhandle = $changehandle ? qa_post_text('handle') : $useraccount['handle'];
+			$inemail = qa_post_text('email');
+			$inmessages = qa_post_text('messages');
+			$inwallposts = qa_post_text('wall');
+			$inmailings = qa_post_text('mailings');
+			$inavatar = qa_post_text('avatar');
 
-		$inprofile=array();
-		foreach ($userfields as $userfield)
-			$inprofile[$userfield['fieldid']]=qa_post_text('field_'.$userfield['fieldid']);
+			$inprofile=array();
+			foreach ($userfields as $userfield)
+			$inprofile[$userfield['fieldid']] = qa_post_text('field_' . $userfield['fieldid']);
 
-		if (!qa_check_form_security_code('account', qa_post_text('code')))
-			$errors['page']=qa_lang_html('misc/form_security_again');
+			if (!qa_check_form_security_code('account', qa_post_text('code')))
+				$errors['page'] = qa_lang_html('misc/form_security_again');
 
-		else {
-			$errors=qa_handle_email_filter($inhandle, $inemail, $useraccount);
+			else {
+				$errors = qa_handle_email_filter($inhandle, $inemail, $useraccount);
 
-			if (!isset($errors['handle']))
-				qa_db_user_set($userid, 'handle', $inhandle);
+				if (!isset($errors['handle']))
+					qa_db_user_set($userid, 'handle', $inhandle);
 
-			if (!isset($errors['email']))
-				if ($inemail != $useraccount['email']) {
+				if (!isset($errors['email']) && $inemail !== $useraccount['email']) {
 					qa_db_user_set($userid, 'email', $inemail);
 					qa_db_user_set_flag($userid, QA_USER_FLAGS_EMAIL_CONFIRMED, false);
-					$isconfirmed=false;
+					$isconfirmed = false;
 
 					if ($doconfirms)
 						qa_send_new_confirm($userid);
 				}
 
-			if (qa_opt('allow_private_messages'))
-				qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_MESSAGES, !$inmessages);
+				if (qa_opt('allow_private_messages'))
+					qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_MESSAGES, !$inmessages);
 
-			if (qa_opt('allow_user_walls'))
-				qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_WALL_POSTS, !$inwallposts);
+				if (qa_opt('allow_user_walls'))
+					qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_WALL_POSTS, !$inwallposts);
 
-			if (qa_opt('mailing_enabled'))
-				qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_MAILINGS, !$inmailings);
+				if (qa_opt('mailing_enabled'))
+					qa_db_user_set_flag($userid, QA_USER_FLAGS_NO_MAILINGS, !$inmailings);
 
-			qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_AVATAR, ($inavatar=='uploaded'));
-			qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_GRAVATAR, ($inavatar=='gravatar'));
+				qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_AVATAR, ($inavatar == 'uploaded'));
+				qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_GRAVATAR, ($inavatar == 'gravatar'));
 
-			if (is_array(@$_FILES['file']) && $_FILES['file']['size']) {
-				require_once QA_INCLUDE_DIR.'qa-app-limits.php';
+				if (is_array(@$_FILES['file'])) {
+					$avatarfileerror = $_FILES['file']['error'];
 
-				switch (qa_user_permit_error(null, QA_LIMIT_UPLOADS))
-				{
-					case 'limit':
-						$errors['avatar']=qa_lang('main/upload_limit');
-						break;
+					// Note if $_FILES['file']['error'] === 1 then upload_max_filesize has been exceeded
+					if ($avatarfileerror === 1)
+						$errors['avatar'] = qa_lang('main/file_upload_limit_exceeded');
+					elseif ($avatarfileerror === 0 && $_FILES['file']['size'] > 0) {
+						require_once QA_INCLUDE_DIR . 'qa-app-limits.php';
 
-					default:
-						$errors['avatar']=qa_lang('users/no_permission');
-						break;
+						switch (qa_user_permit_error(null, QA_LIMIT_UPLOADS)) {
+							case 'limit':
+								$errors['avatar'] = qa_lang('main/upload_limit');
+								break;
 
-					case false:
-						qa_limits_increment($userid, QA_LIMIT_UPLOADS);
+							default:
+								$errors['avatar'] = qa_lang('users/no_permission');
+								break;
 
-						$toobig=qa_image_file_too_big($_FILES['file']['tmp_name'], qa_opt('avatar_store_size'));
+							case false:
+								qa_limits_increment($userid, QA_LIMIT_UPLOADS);
 
-						if ($toobig)
-							$errors['avatar']=qa_lang_sub('main/image_too_big_x_pc', (int)($toobig*100));
-						elseif (!qa_set_user_avatar($userid, file_get_contents($_FILES['file']['tmp_name']), $useraccount['avatarblobid']))
-							$errors['avatar']=qa_lang_sub('main/image_not_read', implode(', ', qa_gd_image_formats()));
-						break;
+								$toobig = qa_image_file_too_big($_FILES['file']['tmp_name'], qa_opt('avatar_store_size'));
+
+								if ($toobig)
+									$errors['avatar'] = qa_lang_sub('main/image_too_big_x_pc', (int) ($toobig * 100));
+								elseif (!qa_set_user_avatar($userid, file_get_contents($_FILES['file']['tmp_name']), $useraccount['avatarblobid']))
+									$errors['avatar'] = qa_lang_sub('main/image_not_read', implode(', ', qa_gd_image_formats()));
+								break;
+						}
+					}  // There shouldn't be any need to catch any other error
+				}
+
+				if (count($inprofile)) {
+					$filtermodules = qa_load_modules_with('filter', 'filter_profile');
+					foreach ($filtermodules as $filtermodule)
+						$filtermodule->filter_profile($inprofile, $errors, $useraccount, $userprofile);
+				}
+
+				foreach ($userfields as $userfield)
+					if (!isset($errors[$userfield['fieldid']]))
+						qa_db_user_profile_set($userid, $userfield['title'], $inprofile[$userfield['fieldid']]);
+
+				list($useraccount, $userprofile) = qa_db_select_with_pending(
+						qa_db_user_account_selectspec($userid, true), qa_db_user_profile_selectspec($userid, true)
+				);
+
+				qa_report_event('u_save', $userid, $useraccount['handle'], qa_cookie_get());
+
+				if (empty($errors))
+					qa_redirect('account', array('state' => 'profile-saved'));
+
+				qa_logged_in_user_flush();
+			}
+		}
+
+
+	//	Process change password if clicked
+
+		if (qa_clicked('dochangepassword')) {
+			require_once QA_INCLUDE_DIR . 'qa-app-users-edit.php';
+
+			$inoldpassword = qa_post_text('oldpassword');
+			$innewpassword1 = qa_post_text('newpassword1');
+			$innewpassword2 = qa_post_text('newpassword2');
+
+			if (!qa_check_form_security_code('password', qa_post_text('code')))
+				$errors['page'] = qa_lang_html('misc/form_security_again');
+
+			else {
+				$errors = array();
+
+				if ($haspassword && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck'])))
+					$errors['oldpassword'] = qa_lang('users/password_wrong');
+
+				$useraccount['password'] = $inoldpassword;
+				$errors = $errors + qa_password_validate($innewpassword1, $useraccount); // array union
+
+				if ($innewpassword1 != $innewpassword2)
+					$errors['newpassword2'] = qa_lang('users/password_mismatch');
+
+				if (empty($errors)) {
+					qa_db_user_set_password($userid, $innewpassword1);
+					qa_db_user_set($userid, 'sessioncode', ''); // stop old 'Remember me' style logins from still working
+					qa_set_logged_in_user($userid, $useraccount['handle'], false, $useraccount['sessionsource']); // reinstate this specific session
+
+					qa_report_event('u_password', $userid, $useraccount['handle'], qa_cookie_get());
+
+					qa_redirect('account', array('state' => 'password-changed'));
 				}
 			}
-
-			if (count($inprofile)) {
-				$filtermodules=qa_load_modules_with('filter', 'filter_profile');
-				foreach ($filtermodules as $filtermodule)
-					$filtermodule->filter_profile($inprofile, $errors, $useraccount, $userprofile);
-			}
-
-			foreach ($userfields as $userfield)
-				if (!isset($errors[$userfield['fieldid']]))
-					qa_db_user_profile_set($userid, $userfield['title'], $inprofile[$userfield['fieldid']]);
-
-			list($useraccount, $userprofile)=qa_db_select_with_pending(
-				qa_db_user_account_selectspec($userid, true),
-				qa_db_user_profile_selectspec($userid, true)
-			);
-
-			qa_report_event('u_save', $userid, $useraccount['handle'], qa_cookie_get());
-
-			if (empty($errors))
-				qa_redirect('account', array('state' => 'profile-saved'));
-
-			qa_logged_in_user_flush();
 		}
 	}
-
-
-//	Process change password if clicked
-
-	if (qa_clicked('dochangepassword')) {
-		require_once QA_INCLUDE_DIR.'qa-app-users-edit.php';
-
-		$inoldpassword=qa_post_text('oldpassword');
-		$innewpassword1=qa_post_text('newpassword1');
-		$innewpassword2=qa_post_text('newpassword2');
-
-		if (!qa_check_form_security_code('password', qa_post_text('code')))
-			$errors['page']=qa_lang_html('misc/form_security_again');
-
-		else {
-			$errors=array();
-
-			if ($haspassword && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck'])))
-				$errors['oldpassword']=qa_lang('users/password_wrong');
-
-			$useraccount['password']=$inoldpassword;
-			$errors=$errors+qa_password_validate($innewpassword1, $useraccount); // array union
-
-			if ($innewpassword1 != $innewpassword2)
-				$errors['newpassword2']=qa_lang('users/password_mismatch');
-
-			if (empty($errors)) {
-				qa_db_user_set_password($userid, $innewpassword1);
-				qa_db_user_set($userid, 'sessioncode', ''); // stop old 'Remember me' style logins from still working
-				qa_set_logged_in_user($userid, $useraccount['handle'], false, $useraccount['sessionsource']); // reinstate this specific session
-
-				qa_report_event('u_password', $userid, $useraccount['handle'], qa_cookie_get());
-
-				qa_redirect('account', array('state' => 'password-changed'));
-			}
-		}
-	}
-
 
 //	Prepare content for theme
 

--- a/qa-include/qa-page-admin-default.php
+++ b/qa-include/qa-page-admin-default.php
@@ -659,104 +659,111 @@
 
 	$formokhtml = null;
 
-	if (qa_clicked('doresetoptions')) {
-		if (!qa_check_form_security_code('admin/'.$adminsection, qa_post_text('code')))
-			$securityexpired = true;
+	// If the post_max_size is exceeded then the $_POST array is empty so no field processing can be done
+	if (qa_is_post_max_size_limit_exceeded())
+		$errors['avatar_default_show'] = qa_lang('main/file_upload_limit_exceeded');
+	else
+		if (qa_clicked('doresetoptions')) {
+			if (!qa_check_form_security_code('admin/' . $adminsection, qa_post_text('code')))
+				$securityexpired = true;
 
-		else {
-			qa_reset_options($getoptions);
-			$formokhtml = qa_lang_html('admin/options_reset');
-		}
-	}
-	elseif (qa_clicked('dosaveoptions')) {
-		if (!qa_check_form_security_code('admin/'.$adminsection, qa_post_text('code')))
-			$securityexpired = true;
-
-		else {
-			foreach ($getoptions as $optionname) {
-				$optionvalue = qa_post_text('option_'.$optionname);
-
-				if (
-					(@$optiontype[$optionname] == 'number') ||
-					(@$optiontype[$optionname] == 'checkbox') ||
-					((@$optiontype[$optionname] == 'number-blank') && strlen($optionvalue))
-				)
-					$optionvalue = (int)$optionvalue;
-
-				if (isset($optionmaximum[$optionname]))
-					$optionvalue = min($optionmaximum[$optionname], $optionvalue);
-
-				if (isset($optionminimum[$optionname]))
-					$optionvalue = max($optionminimum[$optionname], $optionvalue);
-
-				switch ($optionname) {
-					case 'site_url':
-						if (substr($optionvalue, -1) != '/') // seems to be a very common mistake and will mess up URLs
-							$optionvalue .= '/';
-						break;
-
-					case 'hot_weight_views':
-					case 'hot_weight_answers':
-					case 'hot_weight_votes':
-					case 'hot_weight_q_age':
-					case 'hot_weight_a_age':
-						if (qa_opt($optionname) != $optionvalue)
-							$recalchotness = true;
-						break;
-
-					case 'block_ips_write':
-						require_once QA_INCLUDE_DIR.'qa-app-limits.php';
-						$optionvalue = implode(' , ', qa_block_ips_explode($optionvalue));
-						break;
-
-					case 'block_bad_words':
-						require_once QA_INCLUDE_DIR.'qa-util-string.php';
-						$optionvalue = implode(' , ', qa_block_words_explode($optionvalue));
-						break;
-				}
-
-				qa_set_option($optionname, $optionvalue);
+			else {
+				qa_reset_options($getoptions);
+				$formokhtml = qa_lang_html('admin/options_reset');
 			}
+		} elseif (qa_clicked('dosaveoptions')) {
+			if (!qa_check_form_security_code('admin/' . $adminsection, qa_post_text('code')))
+				$securityexpired = true;
 
-			$formokhtml = qa_lang_html('admin/options_saved');
+			else {
+				foreach ($getoptions as $optionname) {
+					$optionvalue = qa_post_text('option_' . $optionname);
 
-		//	Uploading default avatar
+					if (
+							(@$optiontype[$optionname] == 'number') ||
+							(@$optiontype[$optionname] == 'checkbox') ||
+							((@$optiontype[$optionname] == 'number-blank') && strlen($optionvalue))
+					)
+						$optionvalue = (int) $optionvalue;
 
-			if (is_array(@$_FILES['avatar_default_file']) && $_FILES['avatar_default_file']['size']) {
-				require_once QA_INCLUDE_DIR.'qa-util-image.php';
+					if (isset($optionmaximum[$optionname]))
+						$optionvalue = min($optionmaximum[$optionname], $optionvalue);
 
-				$oldblobid = qa_opt('avatar_default_blobid');
+					if (isset($optionminimum[$optionname]))
+						$optionvalue = max($optionminimum[$optionname], $optionvalue);
 
-				$toobig = qa_image_file_too_big($_FILES['avatar_default_file']['tmp_name'], qa_opt('avatar_store_size'));
+					switch ($optionname) {
+						case 'site_url':
+							if (substr($optionvalue, -1) != '/') // seems to be a very common mistake and will mess up URLs
+								$optionvalue .= '/';
+							break;
 
-				if ($toobig)
-					$errors['avatar_default_show'] = qa_lang_sub('main/image_too_big_x_pc', (int)($toobig*100));
+						case 'hot_weight_views':
+						case 'hot_weight_answers':
+						case 'hot_weight_votes':
+						case 'hot_weight_q_age':
+						case 'hot_weight_a_age':
+							if (qa_opt($optionname) != $optionvalue)
+								$recalchotness = true;
+							break;
 
-				else {
-					$imagedata = qa_image_constrain_data(file_get_contents($_FILES['avatar_default_file']['tmp_name']), $width, $height, qa_opt('avatar_store_size'));
+						case 'block_ips_write':
+							require_once QA_INCLUDE_DIR . 'qa-app-limits.php';
+							$optionvalue = implode(' , ', qa_block_ips_explode($optionvalue));
+							break;
 
-					if (isset($imagedata)) {
-						require_once QA_INCLUDE_DIR.'qa-app-blobs.php';
-
-						$newblobid = qa_create_blob($imagedata, 'jpeg');
-
-						if (isset($newblobid)) {
-							qa_set_option('avatar_default_blobid', $newblobid);
-							qa_set_option('avatar_default_width', $width);
-							qa_set_option('avatar_default_height', $height);
-							qa_set_option('avatar_default_show', 1);
-						}
-
-						if (strlen($oldblobid))
-							qa_delete_blob($oldblobid);
-
+						case 'block_bad_words':
+							require_once QA_INCLUDE_DIR . 'qa-util-string.php';
+							$optionvalue = implode(' , ', qa_block_words_explode($optionvalue));
+							break;
 					}
-					else
-						$errors['avatar_default_show'] = qa_lang_sub('main/image_not_read', implode(', ', qa_gd_image_formats()));
+
+					qa_set_option($optionname, $optionvalue);
+				}
+
+				$formokhtml = qa_lang_html('admin/options_saved');
+
+				//	Uploading default avatar
+				if (is_array(@$_FILES['avatar_default_file'])) {
+					$avatarfileerror = $_FILES['avatar_default_file']['error'];
+
+					// Note if $_FILES['avatar_default_file']['error'] === 1 then upload_max_filesize has been exceeded
+					if ($avatarfileerror === 1)
+						$errors['avatar_default_show'] = qa_lang('main/file_upload_limit_exceeded');
+					elseif ($avatarfileerror === 0 && $_FILES['avatar_default_file']['size'] > 0) {
+						require_once QA_INCLUDE_DIR . 'qa-util-image.php';
+
+						$oldblobid = qa_opt('avatar_default_blobid');
+
+						$toobig = qa_image_file_too_big($_FILES['avatar_default_file']['tmp_name'], qa_opt('avatar_store_size'));
+
+						if ($toobig)
+							$errors['avatar_default_show'] = qa_lang_sub('main/image_too_big_x_pc', (int) ($toobig * 100));
+
+						else {
+							$imagedata = qa_image_constrain_data(file_get_contents($_FILES['avatar_default_file']['tmp_name']), $width, $height, qa_opt('avatar_store_size'));
+
+							if (isset($imagedata)) {
+								require_once QA_INCLUDE_DIR . 'qa-app-blobs.php';
+
+								$newblobid = qa_create_blob($imagedata, 'jpeg');
+
+								if (isset($newblobid)) {
+									qa_set_option('avatar_default_blobid', $newblobid);
+									qa_set_option('avatar_default_width', $width);
+									qa_set_option('avatar_default_height', $height);
+									qa_set_option('avatar_default_show', 1);
+								}
+
+								if (strlen($oldblobid))
+									qa_delete_blob($oldblobid);
+							} else
+								$errors['avatar_default_show'] = qa_lang_sub('main/image_not_read', implode(', ', qa_gd_image_formats()));
+						}
+					}
 				}
 			}
 		}
-	}
 
 
 //	Mailings management


### PR DESCRIPTION
This was raised by a user here http://www.question2answer.org/qa/35428

I've explained there what the issue is in detail and the different scenarios that might need to be tackled.

I don't like the idea of repeating code structure in account and admin pages. However, I dislike the idea of adding global functions that turn an $error field on more. Maybe if we were under an MVC framework it would make sense to add that to the controller, but it is not the case.

I have also merged both error messages into one. Letting the user know whether the post_max_size or upload_max_filesize has been exceeded might not make quite a difference. Even the exact value to inform the user as a file limit might be hard to tell (EG: If the user is notified of the maximum file size by means of the upload_max_filesize and the post_max_size happens to be equal or close enough to upload_max_filesize then the user still won't be able to upload a file with a size of upload_max_filesize). So I decided not to get into such a trouble and add a generic message there.

PS: Sorry for so many changes but I had to change the indentation of all the $_POST processing so I thought of also reformatting the code by adding some spaces too
