### PR TITLE
Fixed an issue that allowed null title and content in posts

### DIFF
--- a/qa-include/qa-filter-basic.php
+++ b/qa-include/qa-filter-basic.php
@@ -116,14 +116,12 @@
 		Add textual element $field to $errors if length of $input is not between $minlength and $maxlength
 	*/
 		{
-			if (isset($input)) {
-				$length=qa_strlen($input);
+			$length = isset($input) ? qa_strlen($input) : 0;
 
-				if ($length < $minlength)
-					$errors[$field]=($minlength==1) ? qa_lang('main/field_required') : qa_lang_sub('main/min_length_x', $minlength);
-				elseif (isset($maxlength) && ($length > $maxlength))
-					$errors[$field]=qa_lang_sub('main/max_length_x', $maxlength);
-			}
+			if ($length < $minlength)
+				$errors[$field] = ($minlength == 1) ? qa_lang('main/field_required') : qa_lang_sub('main/min_length_x', $minlength);
+			elseif (isset($maxlength) && ($length > $maxlength))
+				$errors[$field] = qa_lang_sub('main/max_length_x', $maxlength);
 		}
 
 


### PR DESCRIPTION
This fixes bug #63. I'm not sure why there is an explicit null check there but I guess it was just a miss.

Although the issue isn't serious I noticed that questions created this way have not title when displayed in lists and no url associated. This leads to the following logs:

```
PHP Notice:  Undefined index: url in qa-include/qa-theme-base.php on line 1477, referer: http://q2a.com/429/
PHP Notice:  Undefined index: title in qa-include/qa-theme-base.php on line 1477, referer: http://q2a.com/429/
```

Now, although this should fix future posts what should be done with the old posts stored with null title and/or content? Based on the fact that `qa-theme-base.php` is clearly not ready to handle null values I will have to assume that null values shouldn't be allowed in title and content and an empty string should be preferred. This, of course, contradicts the fact that both columns allow null values in them.
So, IMO, in order to avoid adding checks everywhere about null content, I would alter the ^posts table:

```
ALTER TABLE ^posts
CHANGE COLUMN title title VARCHAR(800) NOT NULL DEFAULT '',
CHANGE COLUMN content content VARCHAR(8000) NOT NULL DEFAULT '';
```

I believe current users would benefit from this fix and could perform the changes manually. I would happily post it to the QA site (not the alter table, just the PHP code!). However, maybe @svivian should be the right person to do so.

As usual, this could be added (relatively soon?) to a 1.6.4 release.
