### PR TITLE
[Bugfix - MED] Fixed the private messages reply button

### DIFF
--- a/qa-include/qa-page-messages.php
+++ b/qa-include/qa-page-messages.php
@@ -108,7 +108,7 @@
 			'style' => 'light',
 			'buttons' => array(
 				'reply' => array(
-					'tags' => 'onclick="window.location.href=\''.qa_path_html('message/'.$replyHandle).'\'"',
+					'tags' => 'onclick="window.location.href=\''.qa_path_html('message/'.$replyHandle).'\';return false"',
 					'label' => qa_lang_html('question/reply_button'),
 				),
 				'delete' => array(


### PR DESCRIPTION
Well, I ended up creating a simple pull request after all. It seems the reply button is not working because of the return value of the _onclick_ event. Without using jQuery, and keeping the event handling in an inline JS, I guess the _return false_ is the way to go. However, I'm not 100% sure it will work on all browsers. So far I can confirm it works on Chrome 36 and FF 31.

Source: http://www.question2answer.org/qa/37596/reply-in-to-private-messages-in-alpha-2-1-7
