### PR TITLE
[Bugfix - LOW] Added missing point recalculations

### DIFF
--- a/qa-include/qa-app-post-update.php
+++ b/qa-include/qa-app-post-update.php
@@ -813,6 +813,8 @@
 	Handles indexing (based on $text), user points, cached counts and event reports.
 */
 	{
+		require_once QA_INCLUDE_DIR.'qa-db-votes.php';
+
 		$parent=isset($answers[$parentid]) ? $answers[$parentid] : $question;
 
 		qa_post_unindex($oldanswer['postid']);
@@ -839,6 +841,11 @@
 		qa_update_q_counts_for_a($question['postid']);
 		qa_db_ccount_update();
 		qa_db_points_update_ifuser($oldanswer['userid'], array('aposts', 'aselecteds', 'cposts', 'avoteds'));
+
+		$useridvotes=qa_db_uservote_post_get($oldanswer['postid']);
+		foreach ($useridvotes as $voteruserid => $vote)
+			qa_db_points_update_ifuser($voteruserid, ($vote>0) ? 'aupvotes' : 'adownvotes');
+				// could do this in one query like in qa_db_users_recalc_points() but this will do for now - unlikely to be many votes
 
 		if ($setupdated && $remoderate) {
 			qa_db_queuedcount_update();


### PR DESCRIPTION
Users who vote on an answer that is turned into a comment do not get their points recalculated after the answer becomes a comment. Similar thing happens to the owner of the answer.

Another thing that is actually pending is having the votes zeroed for the new comment. I'm not 100% sure that is the idea because the core seems to be ready to allow voting on comments so maybe the intention is to turn those votes into comment votes.
