### PR TITLE
[Bugfix - MED] Fixed a bug which allowed users to have own votes on posts they own

### DIFF
--- a/qa-include/qa-app-post-update.php
+++ b/qa-include/qa-app-post-update.php
@@ -473,13 +473,19 @@
 	of user. Updates points and reports events as appropriate.
 */
 	{
-		qa_db_post_set_userid($oldquestion['postid'], $userid);
+		require_once QA_INCLUDE_DIR . 'qa-db-votes.php';
+
+		$postid = $oldquestion['postid'];
+
+		qa_db_post_set_userid($postid, $userid);
+		qa_db_remove_owner_votes_from_post($postid);
+		qa_db_post_recount_votes($postid);
 
 		qa_db_points_update_ifuser($oldquestion['userid'], array('qposts', 'aselects', 'qvoteds', 'upvoteds', 'downvoteds'));
-		qa_db_points_update_ifuser($userid, array('qposts', 'aselects', 'qvoteds', 'upvoteds', 'downvoteds'));
+		qa_db_points_update_ifuser($userid, array('qposts', 'aselects', 'qvoteds', 'qupvotes', 'qdownvotes', 'upvoteds', 'downvoteds'));
 
 		qa_report_event('q_claim', $userid, $handle, $cookieid, array(
-			'postid' => $oldquestion['postid'],
+			'postid' => $postid,
 			'oldquestion' => $oldquestion,
 		));
 	}
@@ -726,13 +732,19 @@
 	of user. Updates points and reports events as appropriate.
 */
 	{
-		qa_db_post_set_userid($oldanswer['postid'], $userid);
+		require_once QA_INCLUDE_DIR . 'qa-db-votes.php';
+
+		$postid = $oldanswer['postid'];
+
+		qa_db_post_set_userid($postid, $userid);
+		qa_db_remove_owner_votes_from_post($postid);
+		qa_db_post_recount_votes($postid);
 
 		qa_db_points_update_ifuser($oldanswer['userid'], array('aposts', 'aselecteds', 'avoteds', 'upvoteds', 'downvoteds'));
-		qa_db_points_update_ifuser($userid, array('aposts', 'aselecteds', 'avoteds', 'upvoteds', 'downvoteds'));
+		qa_db_points_update_ifuser($userid, array('aposts', 'aselecteds', 'avoteds', 'aupvotes', 'adownvotes', 'upvoteds', 'downvoteds'));
 
 		qa_report_event('a_claim', $userid, $handle, $cookieid, array(
-			'postid' => $oldanswer['postid'],
+			'postid' => $postid,
 			'parentid' => $oldanswer['parentid'],
 			'oldanswer' => $oldanswer,
 		));
@@ -1030,18 +1042,23 @@
 	of user. Updates points and reports events as appropriate.
 */
 	{
-		qa_db_post_set_userid($oldcomment['postid'], $userid);
+		require_once QA_INCLUDE_DIR . 'qa-db-votes.php';
+
+		$postid = $oldcomment['postid'];
+
+		qa_db_post_set_userid($postid, $userid);
+		qa_db_remove_owner_votes_from_post($postid);
+		qa_db_post_recount_votes($postid);
 
 		qa_db_points_update_ifuser($oldcomment['userid'], array('cposts'));
 		qa_db_points_update_ifuser($userid, array('cposts'));
 
 		qa_report_event('c_claim', $userid, $handle, $cookieid, array(
-			'postid' => $oldcomment['postid'],
+			'postid' => $postid,
 			'parentid' => $oldcomment['parentid'],
 			'oldcomment' => $oldcomment,
 		));
 	}
-
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-include/qa-db-votes.php
+++ b/qa-include/qa-db-votes.php
@@ -150,6 +150,21 @@
 			));
 	}
 
+	/**
+	 * Remove all votes assigned to a post that had been cast by the owner of the post.
+	 *
+	 * @param int $postid The post id which will be removed all votes from its owner.
+	 */
+	function qa_db_remove_owner_votes_from_post($postid)
+	{
+		qa_db_query_sub(
+			'DELETE uv FROM ^uservotes uv ' .
+			'JOIN ^posts p ' .
+			'ON uv.postid = p.postid AND uv.userid = p.userid ' .
+			'WHERE uv.postid = #', $postid
+		);
+	}
+
 
 /*
 	Omit PHP closing tag to help avoid accidental output


### PR DESCRIPTION
Keeping it short, this fixes a bug that allows a user to claim a post that has already been voted by the logged in user.

I would also run the delete statement for all users in the next db version.

As a side note, the coding style guidelines are missing SQL conventions.
