### PR TITLE
[Bugfix - LOW] Prevent users from favoriting themselves

### DIFF
--- a/qa-include/qa-app-favorites.php
+++ b/qa-include/qa-app-favorites.php
@@ -40,38 +40,41 @@
 		require_once QA_INCLUDE_DIR.'qa-app-limits.php';
 		require_once QA_INCLUDE_DIR.'qa-app-updates.php';
 
-		if ($favorite)
-			qa_db_favorite_create($userid, $entitytype, $entityid);
-		else
-			qa_db_favorite_delete($userid, $entitytype, $entityid);
+		// Make sure the user is not favoriting themselves
+		if ($entitytype != QA_ENTITY_USER || $userid != $entityid) {
+			if ($favorite)
+				qa_db_favorite_create($userid, $entitytype, $entityid);
+			else
+				qa_db_favorite_delete($userid, $entitytype, $entityid);
 
-		switch ($entitytype) {
-			case QA_ENTITY_QUESTION:
-				$action=$favorite ? 'q_favorite' : 'q_unfavorite';
-				$params=array('postid' => $entityid);
-				break;
+			switch ($entitytype) {
+				case QA_ENTITY_QUESTION:
+					$action=$favorite ? 'q_favorite' : 'q_unfavorite';
+					$params=array('postid' => $entityid);
+					break;
 
-			case QA_ENTITY_USER:
-				$action=$favorite ? 'u_favorite' : 'u_unfavorite';
-				$params=array('userid' => $entityid);
-				break;
+				case QA_ENTITY_USER:
+					$action=$favorite ? 'u_favorite' : 'u_unfavorite';
+					$params=array('userid' => $entityid);
+					break;
 
-			case QA_ENTITY_TAG:
-				$action=$favorite ? 'tag_favorite' : 'tag_unfavorite';
-				$params=array('wordid' => $entityid);
-				break;
+				case QA_ENTITY_TAG:
+					$action=$favorite ? 'tag_favorite' : 'tag_unfavorite';
+					$params=array('wordid' => $entityid);
+					break;
 
-			case QA_ENTITY_CATEGORY:
-				$action=$favorite ? 'cat_favorite' : 'cat_unfavorite';
-				$params=array('categoryid' => $entityid);
-				break;
+				case QA_ENTITY_CATEGORY:
+					$action=$favorite ? 'cat_favorite' : 'cat_unfavorite';
+					$params=array('categoryid' => $entityid);
+					break;
 
-			default:
-				qa_fatal_error('Favorite type not recognized');
-				break;
+				default:
+					qa_fatal_error('Favorite type not recognized');
+					break;
+			}
+
+			qa_report_event($action, $userid, $handle, $cookieid, $params);
 		}
-
-		qa_report_event($action, $userid, $handle, $cookieid, $params);
 	}
 
 

--- a/qa-include/qa-page-user-profile.php
+++ b/qa-include/qa-page-user-profile.php
@@ -347,7 +347,7 @@
 	$qa_content['title'] = qa_lang_html_sub('profile/user_x', $userhtml);
 	$qa_content['error'] = @$errors['page'];
 
-	if (isset($loginuserid) && !QA_FINAL_EXTERNAL_USERS) {
+	if (isset($loginuserid) && $loginuserid != $useraccount['userid'] && !QA_FINAL_EXTERNAL_USERS) {
 		$favoritemap = qa_get_favorite_non_qs_map();
 		$favorite = @$favoritemap['user'][$useraccount['userid']];
 


### PR DESCRIPTION
It should be noted that changing this should work on any new installation. However, what about the current installations which have users that have already favourited themselves? IMO, they should be removed by running a few update SQL queries in the next DB version. The downside of this is that no event will be fired but still I think is the right way to go as if events get fired and plugins get notified (if there exist any) maybe users won't understand what is going on.
