### PR TITLE
[Improvement - LOW] Base theme now doesn't output h1 tags filled with blanks for unset titles

### DIFF
--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -680,31 +680,33 @@
 
 		public function page_title_error()
 		{
-			$favorite = @$this->content['favorite'];
+			if (isset($this->content['title'])) {
+				$favorite = isset($this->content['favorite']) ? $this->content['favorite'] : null;
 
-			if (isset($favorite))
-				$this->output('<form '.$favorite['form_tags'].'>');
+				if (isset($favorite))
+					$this->output('<form ' . $favorite['form_tags'] . '>');
 
-			$this->output('<h1>');
-			$this->favorite();
-			$this->title();
-			$this->output('</h1>');
+				$this->output('<h1>');
+				$this->favorite();
+				$this->title();
+				$this->output('</h1>');
 
-			if (isset($this->content['error']))
-				$this->error(@$this->content['error']);
-
-			if (isset($favorite)) {
-				$this->form_hidden_elements(@$favorite['form_hidden']);
-				$this->output('</form>');
+				if (isset($favorite)) {
+					$formhidden = isset($favorite['form_hidden']) ? $favorite['form_hidden'] : null;
+					$this->form_hidden_elements($formhidden);
+					$this->output('</form>');
+				}
 			}
+			if (isset($this->content['error']))
+				$this->error($this->content['error']);
 		}
 
 		public function favorite()
 		{
-			$favorite = @$this->content['favorite'];
-
+			$favorite = isset($this->content['favorite']) ? $this->content['favorite'] : null;
 			if (isset($favorite)) {
-				$this->output('<span class="qa-favoriting" '.@$favorite['favorite_tags'].'>');
+				$favoritetags = isset($favorite['favorite_tags']) ? $favorite['favorite_tags'] : '';
+				$this->output('<span class="qa-favoriting" ' . $favoritetags . '>');
 				$this->favorite_inner_html($favorite);
 				$this->output('</span>');
 			}


### PR DESCRIPTION
I noticed some pages have titles not set. For example, the page not found or searching for an empty string. I think it is OK for those pages (and maybe others) to not have titles. However, the h1 tags are being output anyways, which results in not good looking output that can't be easily caught with the CSS pseudo selector `::empty` to be hidden. EG:
![1](https://cloud.githubusercontent.com/assets/1449790/4600954/a546860e-50e4-11e4-8880-35eb32226c6a.png)

That empty blue line is the title. So it either makes no sense to display the title and should be removed or there should be forced a title, which would mean adding a new entry in the lang files. So I guess removing the title is better.

PS: Alternatively, it could be plainly output as `<h1></h1>` which would allow the `::empty` to match it but output the tag that way goes against the base theme _output()_ philosophy :)
