### PR TITLE
[Bugfix - LOW] Fixed an issue in which the handle was not being reported when selecting an answer

### DIFF
--- a/qa-include/qa-app-posts.php
+++ b/qa-include/qa-app-posts.php
@@ -177,7 +177,7 @@
 		if (isset($answerid) && !isset($answers[$answerid]))
 			qa_fatal_error('Answer ID could not be found: '.$answerid);
 
-		qa_question_set_selchildid($byuserid, $byuserid, null, $oldquestion, $answerid, $answers);
+		qa_question_set_selchildid($byuserid, $byhandle, null, $oldquestion, $answerid, $answers);
 	}
 
 


### PR DESCRIPTION
It actually only applies for function `qa_post_set_selchildid` which is never called (at least from the core itself).
