### PR TITLE
[Improvement - HIGH] Removed self sent messages

### DIFF
--- a/qa-include/qa-db-install.php
+++ b/qa-include/qa-db-install.php
@@ -1424,6 +1424,7 @@
 
 				case 58:
 					// Note: need to use full table names here as aliases trigger error "Table 'x' was not locked with LOCK TABLES"
+					qa_db_upgrade_query('DELETE FROM ^messages WHERE type="PRIVATE" AND fromuserid=touserid');
 					qa_db_upgrade_query('DELETE FROM ^userfavorites WHERE entitytype="U" AND userid=entityid');
 					qa_db_upgrade_query('DELETE ^uservotes FROM ^uservotes JOIN ^posts ON ^uservotes.postid=^posts.postid AND ^uservotes.userid=^posts.userid');
 					qa_db_upgrade_query($locktablesquery);


### PR DESCRIPTION
After performing this commit d13ddf711a24124a50741e68e39a6b6ead20d358, a DB clean up should have been added. I understand why db version 58 has been added and I agree with it but adding a 59 just for this is just too much. On the other hand, the sooner this gets merged the less users will be that don't get the clean up run. That's why I set the high priority.
