### PR TITLE
[Improvement - LOW] The profile CSS classes now apply styles to current and future subsections

### DIFF
--- a/qa-theme/SnowFlat/qa-styles-rtl.css
+++ b/qa-theme/SnowFlat/qa-styles-rtl.css
@@ -304,13 +304,12 @@ h1 {
 }
 
 @media (min-width: 980px) {
-	.qa-part-form-profile {
+	.qa-template-user .qa-main > div:first-of-type {
 		float: right;
 	}
 }
-
 @media (min-width: 980px) {
-	.qa-template-user .qa-part-form-activity, .qa-template-user .qa-part-message-list {
+	.qa-template-user .qa-main > div:not(:first-of-type) {
 		float: left;
 		clear: left;
 	}

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -2087,14 +2087,13 @@ input[type="submit"], button {
 }
 
 /*------[ users ]------*/
-.qa-part-form-profile, .qa-part-form-activity, .qa-part-message-list, .qa-part-form-password {
+.qa-template-user .qa-main {
+	width: 100%;
+}
+.qa-template-user .qa-main > div, .qa-template-account .qa-main > div {
 	padding: 20px;
 	margin-bottom: 5px;
 	background: #fff;
-}
-
-.qa-template-user .qa-main {
-	width: 100%;
 }
 .qa-template-user .qa-form-wide-buttons,
 .qa-template-user .qa-form-tall-buttons {
@@ -2177,17 +2176,17 @@ input[type="submit"], button {
 }
 
 @media (min-width: 980px) {
-	.qa-template-user .qa-part-form-profile, .qa-template-user .qa-part-form-activity, .qa-template-user .qa-part-message-list {
+	.qa-template-user .qa-main > div {
 		width: 49.8%;
 	}
 }
 @media (min-width: 980px) {
-	.qa-template-user .qa-part-form-profile {
+	.qa-template-user .qa-main > div:first-of-type {
 		float: left;
 	}
 }
 @media (min-width: 980px) {
-	.qa-template-user .qa-part-form-activity, .qa-template-user .qa-part-message-list {
+	.qa-template-user .qa-main > div:not(:first-of-type) {
 		float: right;
 		clear: right;
 	}


### PR DESCRIPTION
I've introduced 2 changes. First of all, sections not present in the CSS file (new sections added by themes/plugins) will take a default style. This shouldn't interfere with users who want to add sections with a different style as they would have to do it anyways but will make things easier to users who want to add new sections respecting the theme's current styles

The other change I've introduced, and I'm not sure if this is a good a approach or not, is that instead of referencing the profile form (subsection) as the one "on the left" (in LTR) I've changed it to be the first DIV and the rest of the sections aligned "to the right". Suppose a user wants to swap the position of the activity form and the profile form. Currently this could only be done statically by CSS (or programatically spitting CSS). So the user has to know CSS or CSS and PHP. Now, if we take the first DIV then this could still be done by CSS and with only PHP too by sorting the forms in a plugin/theme. So I think this approach has a little pro but y can't think of any cons.
