### PR TITLE
[Bugfix - LOW] Fixed an issue in which plugin page URLs don't respect the site's URLs structure

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1392,8 +1392,8 @@
 	Return the url for $page retrieved from the database
 */
 	{
-		return ($page['flags'] & QA_PAGE_FLAGS_EXTERNAL)
-			? (is_numeric(strpos($page['tags'], '://')) ? $page['tags'] : qa_path_to_root().$page['tags'])
+		return ($page['flags'] & QA_PAGE_FLAGS_EXTERNAL) && (strpos($page['tags'], '://') !== false)
+			? $page['tags']
 			: qa_path($page['tags']);
 	}
 


### PR DESCRIPTION
For some reason, not sure why, it seems they're using the `qa_path_to_root()` explicitly. I think this is a simple bug but maybe I'm missing something here.

In simple terms, if the URL structure is this one `/index.php?qa=123&qa_1=why-do-birds-sing` the current function returns `http://site.com/the-url-here`. The proposed one would return `http://site.com/index.php?qa=the-url-here`.
