### PR TITLE
[Improvement - LOW] Improvements in how numbers are displayed

### DIFF
--- a/qa-include/app/favorites.php
+++ b/qa-include/app/favorites.php
@@ -123,6 +123,7 @@
 			return null;
 
 		require_once QA_INCLUDE_DIR.'app/users.php';
+		require_once QA_INCLUDE_DIR.'app/format.php';
 
 		$ranking = array(
 			'items' => array(),
@@ -137,7 +138,7 @@
 			$ranking['items'][] = array(
 				'avatar' => $avatarhtml,
 				'label' => $usershtml[$user['userid']],
-				'score' => qa_html(number_format($user['points'])),
+				'score' => qa_html(qa_format_number($user['points'])),
 				'raw' => $user,
 			);
 		}
@@ -148,9 +149,11 @@
 
 	function qa_favorite_tags_view($tags)
 /*
-	Returns content to set in $qa_content['ranking_tagss'] for a user's favorite $tags.
+	Returns content to set in $qa_content['ranking_tags'] for a user's favorite $tags.
 */
 	{
+		require_once QA_INCLUDE_DIR.'app/format.php';
+
 		$ranking = array(
 			'items' => array(),
 			'rows' => ceil(count($tags)/qa_opt('columns_tags')),
@@ -160,7 +163,7 @@
 		foreach ($tags as $tag) {
 			$ranking['items'][] = array(
 				'label' => qa_tag_html($tag['word'], false, true),
-				'count' => number_format($tag['tagcount']),
+				'count' => qa_html(qa_format_number($tag['tagcount'])),
 			);
 		}
 
@@ -173,6 +176,8 @@
 	Returns content to set in $qa_content['nav_list_categories'] for a user's favorite $categories.
 */
 	{
+		require_once QA_INCLUDE_DIR.'app/format.php';
+
 		$nav_list_categories = array(
 			'nav' => array(),
 			'type' => 'browse-cat',
@@ -182,7 +187,7 @@
 			$cat_url = qa_path_html( 'questions/' . implode( '/', array_reverse(explode('/', $category['backpath'])) ) );
 			$cat_anchor = $category['qcount'] == 1
 				? qa_lang_html_sub('main/1_question', '1', '1')
-				: qa_lang_html_sub('main/x_questions', number_format($category['qcount']));
+				: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount']));
 			$cat_descr = strlen($category['content']) ? qa_html(' - '.$category['content']) : '';
 
 			$nav_list_categories['nav'][$category['categoryid']] = array(

--- a/qa-include/app/favorites.php
+++ b/qa-include/app/favorites.php
@@ -138,7 +138,7 @@
 			$ranking['items'][] = array(
 				'avatar' => $avatarhtml,
 				'label' => $usershtml[$user['userid']],
-				'score' => qa_html(qa_format_number($user['points'])),
+				'score' => qa_html(qa_format_number($user['points'], 1, true)),
 				'raw' => $user,
 			);
 		}
@@ -163,7 +163,7 @@
 		foreach ($tags as $tag) {
 			$ranking['items'][] = array(
 				'label' => qa_tag_html($tag['word'], false, true),
-				'count' => qa_html(qa_format_number($tag['tagcount'])),
+				'count' => qa_html(qa_format_number($tag['tagcount'], 1, true)),
 			);
 		}
 
@@ -187,7 +187,7 @@
 			$cat_url = qa_path_html( 'questions/' . implode( '/', array_reverse(explode('/', $category['backpath'])) ) );
 			$cat_anchor = $category['qcount'] == 1
 				? qa_lang_html_sub('main/1_question', '1', '1')
-				: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount']));
+				: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount'], 1, true));
 			$cat_descr = strlen($category['content']) ? qa_html(' - '.$category['content']) : '';
 
 			$nav_list_categories['nav'][$category['categoryid']] = array(

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -318,7 +318,7 @@
 				$fields['answers_raw']=$post['acount'];
 
 				$fields['answers']=($post['acount']==1) ? qa_lang_html_sub_split('main/1_answer', '1', '1')
-					: qa_lang_html_sub_split('main/x_answers', qa_format_number($post['acount']));
+					: qa_lang_html_sub_split('main/x_answers', qa_format_number($post['acount'], 1, true));
 
 				$fields['answer_selected']=isset($post['selchildid']);
 			}
@@ -327,7 +327,7 @@
 				$fields['views_raw']=$post['views'];
 
 				$fields['views']=($post['views']==1) ? qa_lang_html_sub_split('main/1_view', '1', '1') :
-					qa_lang_html_sub_split('main/x_views', qa_format_number($post['views']));
+					qa_lang_html_sub_split('main/x_views', qa_format_number($post['views'], 1, true));
 			}
 
 			if (@$options['categoryview'] && isset($post['categoryname']) && isset($post['categorybackpath'])) {
@@ -401,8 +401,8 @@
 
 		//	Create HTML versions...
 
-			$upvoteshtml = qa_html(qa_format_number($upvotes));
-			$downvoteshtml = qa_html(qa_format_number($downvotes));
+			$upvoteshtml = qa_html(qa_format_number($upvotes, 1, true));
+			$downvoteshtml = qa_html(qa_format_number($downvotes, 1, true));
 
 			if ($netvotes >= 1)
 				$netvotesPrefix = '+';
@@ -412,7 +412,7 @@
 				$netvotesPrefix = '';
 
 			$netvotes = abs($netvotes);
-			$netvoteshtml = $netvotesPrefix . qa_html(qa_format_number($netvotes));
+			$netvoteshtml = $netvotesPrefix . qa_html(qa_format_number($netvotes, 1, true));
 
 		//	...with microformats if appropriate
 
@@ -528,7 +528,7 @@
 			if (isset($post['points'])) {
 				if (@$options['pointsview'])
 					$fields['who']['points']=($post['points']==1) ? qa_lang_html_sub_split('main/1_point', '1', '1')
-						: qa_lang_html_sub_split('main/x_points', qa_format_number($post['points']));
+						: qa_lang_html_sub_split('main/x_points', qa_format_number($post['points'], 1, true));
 
 				if (isset($options['pointstitle']))
 					$fields['who']['title']=qa_get_points_title_html($post['points'], $options['pointstitle']);
@@ -854,7 +854,7 @@
 			if (isset($question['opoints'])) {
 				if (@$options['pointsview'])
 					$fields['who']['points']=($question['opoints']==1) ? qa_lang_html_sub_split('main/1_point', '1', '1')
-						: qa_lang_html_sub_split('main/x_points', qa_format_number($question['opoints']));
+						: qa_lang_html_sub_split('main/x_points', qa_format_number($question['opoints'], 1, true));
 
 				if (isset($options['pointstitle']))
 					$fields['who']['title']=qa_get_points_title_html($question['opoints'], $options['pointstitle']);
@@ -1243,7 +1243,7 @@
 					'label' => qa_html($category['title']),
 					'popup' => qa_html(@$category['content']),
 					'selected' => isset($selecteds[$category['categoryid']]),
-					'note' => $showqcount ? ('('.qa_html(qa_format_number($category['qcount'])).')') : null,
+					'note' => $showqcount ? ('('.qa_html(qa_format_number($category['qcount'], 1, true)).')') : null,
 					'subnav' => qa_category_navigation_sub($parentcategories, $category['categoryid'], $selecteds,
 						$pathprefix.$category['tags'].'/', $showqcount, $pathparams, $favoritemap),
 					'categoryid' => $category['categoryid'],

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -393,23 +393,26 @@
 				$downvotes=(int)@$post['downvotes'];
 			}
 
-			$netvotes=(int)($upvotes-$downvotes);
+			$netvotes = $upvotes - $downvotes;
 
-			$fields['upvotes_raw']=$upvotes;
-			$fields['downvotes_raw']=$downvotes;
-			$fields['netvotes_raw']=$netvotes;
+			$fields['upvotes_raw'] = $upvotes;
+			$fields['downvotes_raw'] = $downvotes;
+			$fields['netvotes_raw'] = $netvotes;
 
 		//	Create HTML versions...
 
-			$upvoteshtml=qa_html($upvotes);
-			$downvoteshtml=qa_html($downvotes);
+			$upvoteshtml = qa_html(qa_format_number($upvotes));
+			$downvoteshtml = qa_html(qa_format_number($downvotes));
 
-			if ($netvotes>=1)
-				$netvoteshtml='+'.qa_html($netvotes);
-			elseif ($netvotes<=-1)
-				$netvoteshtml='&ndash;'.qa_html(-$netvotes);
+			if ($netvotes >= 1)
+				$netvotesPrefix = '+';
+			elseif ($netvotes <= -1)
+				$netvotesPrefix = '&ndash;';
 			else
-				$netvoteshtml='0';
+				$netvotesPrefix = '';
+
+			$netvotes = abs($netvotes);
+			$netvoteshtml = $netvotesPrefix . qa_html(qa_format_number($netvotes));
 
 		//	...with microformats if appropriate
 
@@ -436,7 +439,7 @@
 			$fields['downvotes_view']=($downvotes==1) ? qa_lang_html_sub_split('main/1_disliked', $downvoteshtml, '1')
 				: qa_lang_html_sub_split('main/x_disliked', $downvoteshtml);
 
-			$fields['netvotes_view']=(abs($netvotes)==1) ? qa_lang_html_sub_split('main/1_vote', $netvoteshtml, '1')
+			$fields['netvotes_view']=($netvotes==1) ? qa_lang_html_sub_split('main/1_vote', $netvoteshtml, '1')
 				: qa_lang_html_sub_split('main/x_votes', $netvoteshtml);
 
 		//	Voting buttons

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -2043,6 +2043,24 @@
 		);
 	}
 
+	/**
+	 * Format a number using the decimal point and thousand separator specified in the language files
+	 * @param integer $number Number to be formatted
+	 * @param integer $decimals Amount of decimals to use
+	 * @return string The formatted number as a string
+	 */
+	function qa_format_number($number, $decimals = 0)
+	{
+		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
+
+		return number_format(
+			$number,
+			$decimals,
+			qa_lang_html('main/_decimal_point'),
+			qa_lang_html('main/_thousands_separator')
+		);
+	}
+
 
 /*
 	Omit PHP closing tag to help avoid accidental output

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -318,7 +318,7 @@
 				$fields['answers_raw']=$post['acount'];
 
 				$fields['answers']=($post['acount']==1) ? qa_lang_html_sub_split('main/1_answer', '1', '1')
-					: qa_lang_html_sub_split('main/x_answers', number_format($post['acount']));
+					: qa_lang_html_sub_split('main/x_answers', qa_format_number($post['acount']));
 
 				$fields['answer_selected']=isset($post['selchildid']);
 			}
@@ -327,7 +327,7 @@
 				$fields['views_raw']=$post['views'];
 
 				$fields['views']=($post['views']==1) ? qa_lang_html_sub_split('main/1_view', '1', '1') :
-					qa_lang_html_sub_split('main/x_views', number_format($post['views']));
+					qa_lang_html_sub_split('main/x_views', qa_format_number($post['views']));
 			}
 
 			if (@$options['categoryview'] && isset($post['categoryname']) && isset($post['categorybackpath'])) {
@@ -525,7 +525,7 @@
 			if (isset($post['points'])) {
 				if (@$options['pointsview'])
 					$fields['who']['points']=($post['points']==1) ? qa_lang_html_sub_split('main/1_point', '1', '1')
-						: qa_lang_html_sub_split('main/x_points', qa_html(number_format($post['points'])));
+						: qa_lang_html_sub_split('main/x_points', qa_format_number($post['points']));
 
 				if (isset($options['pointstitle']))
 					$fields['who']['title']=qa_get_points_title_html($post['points'], $options['pointstitle']);
@@ -848,11 +848,10 @@
 			$isbyuser=qa_post_is_by_user(array('userid' => $question['ouserid'], 'cookieid' => @$question['ocookieid']), $userid, $cookieid);
 
 			$fields['who']=qa_who_to_html($isbyuser, $question['ouserid'], $usershtml, @$options['ipview'] ? @$question['oip'] : null, false, @$question['oname']);
-
 			if (isset($question['opoints'])) {
 				if (@$options['pointsview'])
 					$fields['who']['points']=($question['opoints']==1) ? qa_lang_html_sub_split('main/1_point', '1', '1')
-						: qa_lang_html_sub_split('main/x_points', qa_html(number_format($question['opoints'])));
+						: qa_lang_html_sub_split('main/x_points', qa_format_number($question['opoints']));
 
 				if (isset($options['pointstitle']))
 					$fields['who']['title']=qa_get_points_title_html($question['opoints'], $options['pointstitle']);
@@ -1241,7 +1240,7 @@
 					'label' => qa_html($category['title']),
 					'popup' => qa_html(@$category['content']),
 					'selected' => isset($selecteds[$category['categoryid']]),
-					'note' => $showqcount ? ('('.qa_html(number_format($category['qcount'])).')') : null,
+					'note' => $showqcount ? ('('.qa_html(qa_format_number($category['qcount'])).')') : null,
 					'subnav' => qa_category_navigation_sub($parentcategories, $category['categoryid'], $selecteds,
 						$pathprefix.$category['tags'].'/', $showqcount, $pathparams, $favoritemap),
 					'categoryid' => $category['categoryid'],

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -2058,7 +2058,7 @@
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		$suffix = '';
-		if ($compact) {
+		if ($compact && qa_opt('show_compact_numbers')) {
 			if ($number != 0) {
 				$base = log($number) / log(1000);
 				$floorBase = floor($base);

--- a/qa-include/app/mailing.php
+++ b/qa-include/app/mailing.php
@@ -137,10 +137,12 @@
 	Return a message describing current progress in the mailing
 */
 	{
+		require_once QA_INCLUDE_DIR . 'app/format.php';
+
 		if (strlen(qa_opt('mailing_last_userid')))
 			return strtr(qa_lang('admin/mailing_progress'), array(
-				'^1' => number_format(qa_opt('mailing_done_users')),
-				'^2' => number_format(qa_opt('mailing_total_users')),
+				'^1' => qa_format_number(qa_opt('mailing_done_users')),
+				'^2' => qa_format_number(qa_opt('mailing_total_users')),
 			));
 		else
 			return null;

--- a/qa-include/app/options.php
+++ b/qa-include/app/options.php
@@ -338,6 +338,7 @@
 			'show_a_c_links' => 1,
 			'show_a_form_immediate' => 'if_no_as',
 			'show_c_reply_buttons' => 1,
+			'show_compact_numbers' => 0,
 			'show_custom_welcome' => 0,
 			'show_post_update_meta' => 1,
 			'show_fewer_cs_count' => 5,

--- a/qa-include/app/recalc.php
+++ b/qa-include/app/recalc.php
@@ -609,12 +609,13 @@
 		return $length;
 	}
 
-
 	function qa_recalc_get_message($state)
 /*
 	Return a string which gives a user-viewable version of $state
 */
 	{
+		require_once QA_INCLUDE_DIR . 'app/format.php';
+
 		@list($operation, $length, $next, $done)=explode("\t", $state);
 
 		$done=(int)$done;
@@ -630,36 +631,36 @@
 
 			case 'doreindexcontent_pagereindex':
 				$message=strtr(qa_lang('admin/reindex_pages_reindexed'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'doreindexcontent_postreindex':
 				$message=strtr(qa_lang('admin/reindex_posts_reindexed'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'doreindexposts_wordcount':
 				$message=strtr(qa_lang('admin/reindex_posts_wordcounted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dorecountposts_votecount':
 				$message=strtr(qa_lang('admin/recount_posts_votes_recounted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dorecountposts_acount':
 				$message=strtr(qa_lang('admin/recount_posts_as_recounted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
@@ -677,8 +678,8 @@
 
 			case 'dorecalcpoints_recalc':
 				$message=strtr(qa_lang('admin/recalc_points_recalced'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
@@ -688,8 +689,8 @@
 
 			case 'dorefillevents_refill':
 				$message=strtr(qa_lang('admin/refill_events_refilled'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
@@ -699,22 +700,22 @@
 
 			case 'dorecalccategories_postupdate':
 				$message=strtr(qa_lang('admin/recalc_categories_updated'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dorecalccategories_recount':
 				$message=strtr(qa_lang('admin/recalc_categories_recounting'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dorecalccategories_backpaths':
 				$message=strtr(qa_lang('admin/recalc_categories_backpaths'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
@@ -724,22 +725,22 @@
 
 			case 'dodeletehidden_comments':
 				$message=strtr(qa_lang('admin/hidden_comments_deleted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dodeletehidden_answers':
 				$message=strtr(qa_lang('admin/hidden_answers_deleted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
 			case 'dodeletehidden_questions':
 				$message=strtr(qa_lang('admin/hidden_questions_deleted'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 
@@ -750,8 +751,8 @@
 			case 'doblobstodisk_move':
 			case 'doblobstodb_move':
 				$message=strtr(qa_lang('admin/blobs_move_moved'), array(
-					'^1' => number_format($done),
-					'^2' => number_format($length)
+					'^1' => qa_format_number($done),
+					'^2' => qa_format_number($length)
 				));
 				break;
 

--- a/qa-include/app/recalc.php
+++ b/qa-include/app/recalc.php
@@ -609,6 +609,24 @@
 		return $length;
 	}
 
+
+	/**
+	 * Return the translated language ID string replacing the progress and total in it
+	 * @param string $langId Language string ID that contains 2 placeholders (^1 and ^2)
+	 * @param int $progress Amount of processed elements
+	 * @param int $total Total amount of elements
+	 * @return string Returns the language string ID with their placeholders replaced with
+	 * the formatted progress and total numbers
+	 */
+	function qa_private_translate_with_progress($langId, $progress, $total)
+	{
+		return strtr(qa_lang($langId), array(
+			'^1' => qa_format_number($progress),
+			'^2' => qa_format_number($total)
+		));
+	}
+
+
 	function qa_recalc_get_message($state)
 /*
 	Return a string which gives a user-viewable version of $state
@@ -616,153 +634,111 @@
 	{
 		require_once QA_INCLUDE_DIR . 'app/format.php';
 
-		@list($operation, $length, $next, $done)=explode("\t", $state);
+		@list($operation, $length, $next, $done) = explode("\t", $state);
 
-		$done=(int)$done;
-		$length=(int)$length;
+		$done = (int) $done;
+		$length = (int) $length;
 
 		switch ($operation) {
 			case 'doreindexcontent_postcount':
 			case 'dorecountposts_postcount':
 			case 'dorecalccategories_postcount':
 			case 'dorefillevents_qcount':
-				$message=qa_lang('admin/recalc_posts_count');
+				$message = qa_lang('admin/recalc_posts_count');
 				break;
 
 			case 'doreindexcontent_pagereindex':
-				$message=strtr(qa_lang('admin/reindex_pages_reindexed'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/reindex_pages_reindexed', $done, $length);
 				break;
 
 			case 'doreindexcontent_postreindex':
-				$message=strtr(qa_lang('admin/reindex_posts_reindexed'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
-				break;
-
-			case 'doreindexposts_wordcount':
-				$message=strtr(qa_lang('admin/reindex_posts_wordcounted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
-				break;
-
-			case 'dorecountposts_votecount':
-				$message=strtr(qa_lang('admin/recount_posts_votes_recounted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
-				break;
-
-			case 'dorecountposts_acount':
-				$message=strtr(qa_lang('admin/recount_posts_as_recounted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/reindex_posts_reindexed', $done, $length);
 				break;
 
 			case 'doreindexposts_complete':
-				$message=qa_lang('admin/reindex_posts_complete');
+				$message = qa_lang('admin/reindex_posts_complete');
+				break;
+
+			case 'doreindexposts_wordcount':
+				$message = qa_private_translate_with_progress('admin/reindex_posts_wordcounted', $done, $length);
+				break;
+
+			case 'dorecountposts_votecount':
+				$message = qa_private_translate_with_progress('admin/recount_posts_votes_recounted', $done, $length);
+				break;
+
+			case 'dorecountposts_acount':
+				$message = qa_private_translate_with_progress('admin/recount_posts_as_recounted', $done, $length);
 				break;
 
 			case 'dorecountposts_complete':
-				$message=qa_lang('admin/recount_posts_complete');
+				$message = qa_lang('admin/recount_posts_complete');
 				break;
 
 			case 'dorecalcpoints_usercount':
-				$message=qa_lang('admin/recalc_points_usercount');
+				$message = qa_lang('admin/recalc_points_usercount');
 				break;
 
 			case 'dorecalcpoints_recalc':
-				$message=strtr(qa_lang('admin/recalc_points_recalced'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/recalc_points_recalced', $done, $length);
 				break;
 
 			case 'dorecalcpoints_complete':
-				$message=qa_lang('admin/recalc_points_complete');
+				$message = qa_lang('admin/recalc_points_complete');
 				break;
 
 			case 'dorefillevents_refill':
-				$message=strtr(qa_lang('admin/refill_events_refilled'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/refill_events_refilled', $done, $length);
 				break;
 
 			case 'dorefillevents_complete':
-				$message=qa_lang('admin/refill_events_complete');
+				$message = qa_lang('admin/refill_events_complete');
 				break;
 
 			case 'dorecalccategories_postupdate':
-				$message=strtr(qa_lang('admin/recalc_categories_updated'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/recalc_categories_updated', $done, $length);
 				break;
 
 			case 'dorecalccategories_recount':
-				$message=strtr(qa_lang('admin/recalc_categories_recounting'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/recalc_categories_recounting', $done, $length);
 				break;
 
 			case 'dorecalccategories_backpaths':
-				$message=strtr(qa_lang('admin/recalc_categories_backpaths'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/recalc_categories_backpaths', $done, $length);
 				break;
 
 			case 'dorecalccategories_complete':
-				$message=qa_lang('admin/recalc_categories_complete');
+				$message = qa_lang('admin/recalc_categories_complete');
 				break;
 
 			case 'dodeletehidden_comments':
-				$message=strtr(qa_lang('admin/hidden_comments_deleted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/hidden_comments_deleted', $done, $length);
 				break;
 
 			case 'dodeletehidden_answers':
-				$message=strtr(qa_lang('admin/hidden_answers_deleted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/hidden_answers_deleted', $done, $length);
 				break;
 
 			case 'dodeletehidden_questions':
-				$message=strtr(qa_lang('admin/hidden_questions_deleted'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/hidden_questions_deleted', $done, $length);
 				break;
 
 			case 'dodeletehidden_complete':
-				$message=qa_lang('admin/delete_hidden_complete');
+				$message = qa_lang('admin/delete_hidden_complete');
 				break;
 
 			case 'doblobstodisk_move':
 			case 'doblobstodb_move':
-				$message=strtr(qa_lang('admin/blobs_move_moved'), array(
-					'^1' => qa_format_number($done),
-					'^2' => qa_format_number($length)
-				));
+				$message = qa_private_translate_with_progress('admin/blobs_move_moved', $done, $length);
 				break;
 
 			case 'doblobstodisk_complete':
 			case 'doblobstodb_complete':
-				$message=qa_lang('admin/blobs_move_complete');
+				$message = qa_lang('admin/blobs_move_complete');
 				break;
 
 			default:
-				$message='';
+				$message = '';
 				break;
 		}
 

--- a/qa-include/app/upload.php
+++ b/qa-include/app/upload.php
@@ -102,7 +102,7 @@
 			$maxfilesize=qa_get_max_upload_size();
 
 		if ( ($filesize<=0) || ($filesize>$maxfilesize) ) { // if file was too big for PHP, $filesize will be zero
-			$result['error']=qa_lang_sub('main/max_upload_size_x', number_format($maxfilesize/1048576, 1).'MB');
+			$result['error']=qa_lang_sub('main/max_upload_size_x', qa_format_number($maxfilesize/1048576, 1).'MB');
 			return $result;
 		}
 

--- a/qa-include/lang/qa-lang-main.php
+++ b/qa-include/lang/qa-lang-main.php
@@ -23,6 +23,8 @@
 	return array(
 		'_decimal_point' => '.',
 		'_thousands_separator' => ',',
+		'_thousands_suffix' => 'k',
+		'_millions_suffix' => 'm',
 		'1_answer' => '1 answer',
 		'1_comment' => '1 comment',
 		'1_day' => '1 day',

--- a/qa-include/lang/qa-lang-main.php
+++ b/qa-include/lang/qa-lang-main.php
@@ -21,6 +21,8 @@
 */
 
 	return array(
+		'_decimal_point' => '.',
+		'_thousands_separator' => ',',
 		'1_answer' => '1 answer',
 		'1_comment' => '1 comment',
 		'1_day' => '1 day',

--- a/qa-include/lang/qa-lang-options.php
+++ b/qa-include/lang/qa-lang-options.php
@@ -227,6 +227,7 @@
 		'show_a_form_immediate' => 'Show answer form immediately:',
 		'show_always' => 'Always',
 		'show_c_reply_buttons' => 'Show reply button on comments:',
+		'show_compact_numbers' => 'Show compact numbers (e.g., 1.3k):',
 		'show_custom_answer' => 'Custom message on answer form - HTML allowed:',
 		'show_custom_ask' => 'Custom message on ask form - HTML allowed:',
 		'show_custom_comment' => 'Custom message on comment form - HTML allowed:',

--- a/qa-include/pages/admin/admin-categories.php
+++ b/qa-include/pages/admin/admin-categories.php
@@ -28,6 +28,7 @@
 	require_once QA_INCLUDE_DIR.'app/admin.php';
 	require_once QA_INCLUDE_DIR.'db/selects.php';
 	require_once QA_INCLUDE_DIR.'db/admin.php';
+	require_once QA_INCLUDE_DIR.'app/format.php';
 
 
 //	Get relevant list of categories
@@ -395,7 +396,7 @@
 				'value' => '<a href="'.qa_path_html('questions/'.qa_category_path_request($categories, $editcategory['categoryid'])).'">'.
 								( ($editcategory['qcount']==1)
 									? qa_lang_html_sub('main/1_question', '1', '1')
-									: qa_lang_html_sub('main/x_questions', number_format($editcategory['qcount']))
+									: qa_lang_html_sub('main/x_questions', qa_format_number($editcategory['qcount']))
 								).'</a>',
 			);
 
@@ -405,7 +406,7 @@
 				if ($nosubcount)
 					$qa_content['form']['fields']['questions']['error']=
 						strtr(qa_lang_html('admin/category_no_sub_error'), array(
-							'^q' => number_format($nosubcount),
+							'^q' => qa_format_number($nosubcount),
 							'^1' => '<a href="'.qa_path_html(qa_request(), array('edit' => $editcategory['categoryid'], 'missing' => 1)).'">',
 							'^2' => '</a>',
 						));
@@ -559,8 +560,15 @@
 
 			foreach ($categories as $category)
 				if (!isset($category['parentid']))
-					$navcategoryhtml.='<a href="'.qa_path_html('admin/categories', array('edit' => $category['categoryid'])).'">'.
-						qa_html($category['title']).'</a> - '.qa_lang_html_sub('main/x_questions', $category['qcount']).'<br/>';
+					$navcategoryhtml .=
+						'<a href="' . qa_path_html('admin/categories', array('edit' => $category['categoryid'])) . '">' .
+							qa_html($category['title']) .
+						'</a> - ' .
+						($category['qcount'] == 1
+							? qa_lang_html_sub('main/1_question', '1', '1')
+							: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount']))
+						) . '<br/>'
+					;
 
 			$qa_content['form']['fields']['nav']=array(
 				'label' => qa_lang_html('admin/top_level_categories'),
@@ -581,7 +589,7 @@
 				if ($nocatcount)
 					$qa_content['form']['fields']['allow_no_category']['error']=
 						strtr(qa_lang_html('admin/category_none_error'), array(
-							'^q' => number_format($nocatcount),
+							'^q' => qa_format_number($nocatcount),
 							'^1' => '<a href="'.qa_path_html(qa_request(), array('missing' => 1)).'">',
 							'^2' => '</a>',
 						));

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -188,6 +188,7 @@
 		'q_urls_remove_accents' => 'checkbox',
 		'register_notify_admin' => 'checkbox',
 		'show_c_reply_buttons' => 'checkbox',
+		'show_compact_numbers' => 'checkbox',
 		'show_custom_answer' => 'checkbox',
 		'show_custom_ask' => 'checkbox',
 		'show_custom_comment' => 'checkbox',
@@ -199,11 +200,11 @@
 		'show_custom_sidebar' => 'checkbox',
 		'show_custom_sidepanel' => 'checkbox',
 		'show_custom_welcome' => 'checkbox',
-		'show_post_update_meta' => 'checkbox',
 		'show_home_description' => 'checkbox',
 		'show_message_history' => 'checkbox',
 		'show_notice_visitor' => 'checkbox',
 		'show_notice_welcome' => 'checkbox',
+		'show_post_update_meta' => 'checkbox',
 		'show_register_terms' => 'checkbox',
 		'show_selected_first' => 'checkbox',
 		'show_url_links' => 'checkbox',
@@ -390,7 +391,7 @@
 					break;
 				}
 
-			$showoptions[] = 'pages_prev_next';
+			array_push($showoptions, 'pages_prev_next', '', 'show_compact_numbers');
 
 			$formstyle = 'wide';
 

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -1527,6 +1527,8 @@
 
 	switch ($adminsection) {
 		case 'users':
+			require_once QA_INCLUDE_DIR . 'app/format.php';
+
 			if (!QA_FINAL_EXTERNAL_USERS) {
 				$userfields = qa_db_single_select(qa_db_userfields_selectspec());
 
@@ -1564,7 +1566,7 @@
 
 			foreach ($pointstitle as $points => $title) {
 				$listhtml .= '<li><b>'.$title.'</b> - '.(($points == 1) ? qa_lang_html_sub('main/1_point', '1', '1')
-				: qa_lang_html_sub('main/x_points', qa_html(number_format($points))));
+				: qa_lang_html_sub('main/x_points', qa_html(qa_format_number($points))));
 
 				$listhtml .= strtr(qa_lang_html('admin/edit_title'), array(
 					'^1' => '<a href="'.qa_path_html('admin/usertitles', array('edit' => $points)).'">',

--- a/qa-include/pages/admin/admin-stats.php
+++ b/qa-include/pages/admin/admin-stats.php
@@ -28,6 +28,7 @@
 	require_once QA_INCLUDE_DIR.'db/recalc.php';
 	require_once QA_INCLUDE_DIR.'app/admin.php';
 	require_once QA_INCLUDE_DIR.'db/admin.php';
+	require_once QA_INCLUDE_DIR.'app/format.php';
 
 
 //	Check admin privileges (do late to allow one DB query)
@@ -88,7 +89,7 @@
 
 			'db_size' => array(
 				'label' => qa_lang_html('admin/q2a_db_size'),
-				'value' => qa_html(number_format(qa_db_table_size()/1048576, 1).' MB'),
+				'value' => qa_html(qa_format_number(qa_db_table_size() / 1048576, 1) . ' MB'),
 			),
 
 			'break1' => array(
@@ -111,17 +112,17 @@
 
 			'qcount' => array(
 				'label' => qa_lang_html('admin/total_qs'),
-				'value' => qa_html(number_format($qcount)),
+				'value' => qa_html(qa_format_number($qcount)),
 			),
 
 			'qcount_users' => array(
 				'label' => qa_lang_html('admin/from_users'),
-				'value' => qa_html(number_format($qcount-$qcount_anon)),
+				'value' => qa_html(qa_format_number($qcount-$qcount_anon)),
 			),
 
 			'qcount_anon' => array(
 				'label' => qa_lang_html('admin/from_anon'),
-				'value' => qa_html(number_format($qcount_anon)),
+				'value' => qa_html(qa_format_number($qcount_anon)),
 			),
 
 			'break3' => array(
@@ -130,17 +131,17 @@
 
 			'acount' => array(
 				'label' => qa_lang_html('admin/total_as'),
-				'value' => qa_html(number_format($acount)),
+				'value' => qa_html(qa_format_number($acount)),
 			),
 
 			'acount_users' => array(
 				'label' => qa_lang_html('admin/from_users'),
-				'value' => qa_html(number_format($acount-$acount_anon)),
+				'value' => qa_html(qa_format_number($acount-$acount_anon)),
 			),
 
 			'acount_anon' => array(
 				'label' => qa_lang_html('admin/from_anon'),
-				'value' => qa_html(number_format($acount_anon)),
+				'value' => qa_html(qa_format_number($acount_anon)),
 			),
 
 			'break4' => array(
@@ -149,17 +150,17 @@
 
 			'ccount' => array(
 				'label' => qa_lang_html('admin/total_cs'),
-				'value' => qa_html(number_format($ccount)),
+				'value' => qa_html(qa_format_number($ccount)),
 			),
 
 			'ccount_users' => array(
 				'label' => qa_lang_html('admin/from_users'),
-				'value' => qa_html(number_format($ccount-$ccount_anon)),
+				'value' => qa_html(qa_format_number($ccount-$ccount_anon)),
 			),
 
 			'ccount_anon' => array(
 				'label' => qa_lang_html('admin/from_anon'),
-				'value' => qa_html(number_format($ccount_anon)),
+				'value' => qa_html(qa_format_number($ccount_anon)),
 			),
 
 			'break5' => array(
@@ -168,22 +169,22 @@
 
 			'users' => array(
 				'label' => qa_lang_html('admin/users_registered'),
-				'value' => QA_FINAL_EXTERNAL_USERS ? '' : qa_html(number_format(qa_db_count_users())),
+				'value' => QA_FINAL_EXTERNAL_USERS ? '' : qa_html(qa_format_number(qa_db_count_users())),
 			),
 
 			'users_active' => array(
 				'label' => qa_lang_html('admin/users_active'),
-				'value' => qa_html(number_format((int)qa_opt('cache_userpointscount'))),
+				'value' => qa_html(qa_format_number((int) qa_opt('cache_userpointscount'))),
 			),
 
 			'users_posted' => array(
 				'label' => qa_lang_html('admin/users_posted'),
-				'value' => qa_html(number_format(qa_db_count_active_users('posts'))),
+				'value' => qa_html(qa_format_number(qa_db_count_active_users('posts'))),
 			),
 
 			'users_voted' => array(
 				'label' => qa_lang_html('admin/users_voted'),
-				'value' => qa_html(number_format(qa_db_count_active_users('uservotes'))),
+				'value' => qa_html(qa_format_number(qa_db_count_active_users('uservotes'))),
 			),
 		),
 	);

--- a/qa-include/pages/categories.php
+++ b/qa-include/pages/categories.php
@@ -69,7 +69,7 @@
 			$navigation[$key]['note'].=
 				' - <a href="'.qa_path_html('questions/'.implode('/', array_reverse(explode('/', $category['backpath'])))).'">'.( ($category['qcount']==1)
 					? qa_lang_html_sub('main/1_question', '1', '1')
-					: qa_lang_html_sub('main/x_questions', number_format($category['qcount']))
+					: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount']))
 				).'</a>';
 
 			if (strlen($category['content']))

--- a/qa-include/pages/categories.php
+++ b/qa-include/pages/categories.php
@@ -69,7 +69,7 @@
 			$navigation[$key]['note'].=
 				' - <a href="'.qa_path_html('questions/'.implode('/', array_reverse(explode('/', $category['backpath'])))).'">'.( ($category['qcount']==1)
 					? qa_lang_html_sub('main/1_question', '1', '1')
-					: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount']))
+					: qa_lang_html_sub('main/x_questions', qa_format_number($category['qcount'], 1, true))
 				).'</a>';
 
 			if (strlen($category['content']))

--- a/qa-include/pages/tags.php
+++ b/qa-include/pages/tags.php
@@ -60,7 +60,7 @@
 		foreach ($populartags as $word => $count) {
 			$qa_content['ranking']['items'][] = array(
 				'label' => qa_tag_html($word, false, @$favoritemap['tag'][qa_strtolower($word)]),
-				'count' => number_format($count),
+				'count' => qa_format_number($count),
 			);
 
 			if ((++$output) >= $pagesize)

--- a/qa-include/pages/tags.php
+++ b/qa-include/pages/tags.php
@@ -60,7 +60,7 @@
 		foreach ($populartags as $word => $count) {
 			$qa_content['ranking']['items'][] = array(
 				'label' => qa_tag_html($word, false, @$favoritemap['tag'][qa_strtolower($word)]),
-				'count' => qa_format_number($count),
+				'count' => qa_format_number($count, 1, true),
 			);
 
 			if ((++$output) >= $pagesize)

--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -774,7 +774,7 @@
 				'label' => qa_lang_html('profile/score'),
 				'value' => (@$userpoints['points'] == 1)
 					? qa_lang_html_sub('main/1_point', '<span class="qa-uf-user-points">1</span>', '1')
-					: qa_lang_html_sub('main/x_points', '<span class="qa-uf-user-points">'.qa_html(number_format(@$userpoints['points'])).'</span>'),
+					: qa_lang_html_sub('main/x_points', '<span class="qa-uf-user-points">'.qa_html(qa_format_number(@$userpoints['points'])).'</span>'),
 				'id' => 'points',
 			),
 
@@ -788,14 +788,14 @@
 			'questions' => array(
 				'type' => 'static',
 				'label' => qa_lang_html('profile/questions'),
-				'value' => '<span class="qa-uf-user-q-posts">'.qa_html(number_format(@$userpoints['qposts'])).'</span>',
+				'value' => '<span class="qa-uf-user-q-posts">'.qa_html(qa_format_number(@$userpoints['qposts'])).'</span>',
 				'id' => 'questions',
 			),
 
 			'answers' => array(
 				'type' => 'static',
 				'label' => qa_lang_html('profile/answers'),
-				'value' => '<span class="qa-uf-user-a-posts">'.qa_html(number_format(@$userpoints['aposts'])).'</span>',
+				'value' => '<span class="qa-uf-user-a-posts">'.qa_html(qa_format_number(@$userpoints['aposts'])).'</span>',
 				'id' => 'answers',
 			),
 		),
@@ -826,7 +826,7 @@
 		$qa_content['form_activity']['fields']['comments'] = array(
 			'type' => 'static',
 			'label' => qa_lang_html('profile/comments'),
-			'value' => '<span class="qa-uf-user-c-posts">'.qa_html(number_format(@$userpoints['cposts'])).'</span>',
+			'value' => '<span class="qa-uf-user-c-posts">'.qa_html(qa_format_number(@$userpoints['cposts'])).'</span>',
 			'id' => 'comments',
 		);
 	}
@@ -837,7 +837,7 @@
 		if (qa_opt('voting_on_qs')) {
 			$qvotes = @$userpoints['qupvotes']+@$userpoints['qdownvotes'];
 
-			$innervalue = '<span class="qa-uf-user-q-votes">'.number_format($qvotes).'</span>';
+			$innervalue = '<span class="qa-uf-user-q-votes">'.qa_format_number($qvotes).'</span>';
 			$votedonvalue .= ($qvotes == 1) ? qa_lang_html_sub('main/1_question', $innervalue, '1')
 				: qa_lang_html_sub('main/x_questions', $innervalue);
 
@@ -848,7 +848,7 @@
 		if (qa_opt('voting_on_as')) {
 			$avotes = @$userpoints['aupvotes']+@$userpoints['adownvotes'];
 
-			$innervalue = '<span class="qa-uf-user-a-votes">'.number_format($avotes).'</span>';
+			$innervalue = '<span class="qa-uf-user-a-votes">'.qa_format_number($avotes).'</span>';
 			$votedonvalue .= ($avotes == 1) ? qa_lang_html_sub('main/1_answer', $innervalue, '1')
 				: qa_lang_html_sub('main/x_answers', $innervalue);
 		}
@@ -861,11 +861,11 @@
 		);
 
 		$upvotes = @$userpoints['qupvotes']+@$userpoints['aupvotes'];
-		$innervalue = '<span class="qa-uf-user-upvotes">'.number_format($upvotes).'</span>';
+		$innervalue = '<span class="qa-uf-user-upvotes">'.qa_format_number($upvotes).'</span>';
 		$votegavevalue = (($upvotes == 1) ? qa_lang_html_sub('profile/1_up_vote', $innervalue, '1') : qa_lang_html_sub('profile/x_up_votes', $innervalue)).', ';
 
 		$downvotes = @$userpoints['qdownvotes']+@$userpoints['adownvotes'];
-		$innervalue = '<span class="qa-uf-user-downvotes">'.number_format($downvotes).'</span>';
+		$innervalue = '<span class="qa-uf-user-downvotes">'.qa_format_number($downvotes).'</span>';
 		$votegavevalue .= ($downvotes == 1) ? qa_lang_html_sub('profile/1_down_vote', $innervalue, '1') : qa_lang_html_sub('profile/x_down_votes', $innervalue);
 
 		$qa_content['form_activity']['fields']['votegave'] = array(
@@ -875,11 +875,11 @@
 			'id' => 'votegave',
 		);
 
-		$innervalue = '<span class="qa-uf-user-upvoteds">'.number_format(@$userpoints['upvoteds']).'</span>';
+		$innervalue = '<span class="qa-uf-user-upvoteds">'.qa_format_number(@$userpoints['upvoteds']).'</span>';
 		$votegotvalue = ((@$userpoints['upvoteds'] == 1) ? qa_lang_html_sub('profile/1_up_vote', $innervalue, '1')
 			: qa_lang_html_sub('profile/x_up_votes', $innervalue)).', ';
 
-		$innervalue = '<span class="qa-uf-user-downvoteds">'.number_format(@$userpoints['downvoteds']).'</span>';
+		$innervalue = '<span class="qa-uf-user-downvoteds">'.qa_format_number(@$userpoints['downvoteds']).'</span>';
 		$votegotvalue .= (@$userpoints['downvoteds'] == 1) ? qa_lang_html_sub('profile/1_down_vote', $innervalue, '1')
 			: qa_lang_html_sub('profile/x_down_votes', $innervalue);
 
@@ -893,19 +893,19 @@
 
 	if (@$userpoints['points']) {
 		$qa_content['form_activity']['fields']['points']['value'] .=
-			qa_lang_html_sub('profile/ranked_x', '<span class="qa-uf-user-rank">'.number_format($userrank).'</span>');
+			qa_lang_html_sub('profile/ranked_x', '<span class="qa-uf-user-rank">'.qa_format_number($userrank).'</span>');
 	}
 
 	if (@$userpoints['aselects']) {
 		$qa_content['form_activity']['fields']['questions']['value'] .= ($userpoints['aselects'] == 1)
 			? qa_lang_html_sub('profile/1_with_best_chosen', '<span class="qa-uf-user-q-selects">1</span>', '1')
-			: qa_lang_html_sub('profile/x_with_best_chosen', '<span class="qa-uf-user-q-selects">'.number_format($userpoints['aselects']).'</span>');
+			: qa_lang_html_sub('profile/x_with_best_chosen', '<span class="qa-uf-user-q-selects">'.qa_format_number($userpoints['aselects']).'</span>');
 	}
 
 	if (@$userpoints['aselecteds']) {
 		$qa_content['form_activity']['fields']['answers']['value'] .= ($userpoints['aselecteds'] == 1)
 			? qa_lang_html_sub('profile/1_chosen_as_best', '<span class="qa-uf-user-a-selecteds">1</span>', '1')
-			: qa_lang_html_sub('profile/x_chosen_as_best', '<span class="qa-uf-user-a-selecteds">'.number_format($userpoints['aselecteds']).'</span>');
+			: qa_lang_html_sub('profile/x_chosen_as_best', '<span class="qa-uf-user-a-selecteds">'.qa_format_number($userpoints['aselecteds']).'</span>');
 	}
 
 

--- a/qa-include/pages/users.php
+++ b/qa-include/pages/users.php
@@ -66,7 +66,7 @@
 			$qa_content['ranking']['items'][] = array(
 				'avatar' => $avatarhtml,
 				'label' => $usershtml[$user['userid']],
-				'score' => qa_html(qa_format_number($user['points'])),
+				'score' => qa_html(qa_format_number($user['points'], 1, true)),
 				'raw' => $user,
 			);
 		}

--- a/qa-include/pages/users.php
+++ b/qa-include/pages/users.php
@@ -66,7 +66,7 @@
 			$qa_content['ranking']['items'][] = array(
 				'avatar' => $avatarhtml,
 				'label' => $usershtml[$user['userid']],
-				'score' => qa_html(number_format($user['points'])),
+				'score' => qa_html(qa_format_number($user['points'])),
 				'raw' => $user,
 			);
 		}

--- a/qa-include/plugins/qa-widget-activity-count.php
+++ b/qa-include/plugins/qa-widget-activity-count.php
@@ -49,12 +49,14 @@ class qa_activity_count
 
 	public function output_count($themeobject, $value, $langsingular, $langplural)
 	{
+		require_once QA_INCLUDE_DIR . 'app/format.php';
+
 		$themeobject->output('<p class="qa-activity-count-item">');
 
 		if ($value==1)
 			$themeobject->output(qa_lang_html_sub($langsingular, '<span class="qa-activity-count-data">1</span>', '1'));
 		else
-			$themeobject->output(qa_lang_html_sub($langplural, '<span class="qa-activity-count-data">'.number_format((int)$value).'</span>'));
+			$themeobject->output(qa_lang_html_sub($langplural, '<span class="qa-activity-count-data">'.qa_format_number((int)$value).'</span>'));
 
 		$themeobject->output('</p>');
 	}

--- a/qa-include/plugins/qa-widget-activity-count.php
+++ b/qa-include/plugins/qa-widget-activity-count.php
@@ -56,7 +56,7 @@ class qa_activity_count
 		if ($value==1)
 			$themeobject->output(qa_lang_html_sub($langsingular, '<span class="qa-activity-count-data">1</span>', '1'));
 		else
-			$themeobject->output(qa_lang_html_sub($langplural, '<span class="qa-activity-count-data">'.qa_format_number((int)$value).'</span>'));
+			$themeobject->output(qa_lang_html_sub($langplural, '<span class="qa-activity-count-data">'.qa_format_number((int) $value, 1, true).'</span>'));
 
 		$themeobject->output('</p>');
 	}

--- a/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
+++ b/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
@@ -79,9 +79,9 @@ class qa_wysiwyg_editor
 				array(
 					'id' => 'wysiwyg_editor_upload_max_size_display',
 					'label' => 'Maximum size of uploads:',
-					'suffix' => 'MB (max '.$this->bytes_to_mega_html(qa_get_max_upload_size()).')',
+					'suffix' => 'MB (max '.qa_html(qa_format_number($this->bytes_to_mega(qa_get_max_upload_size()))).')',
 					'type' => 'number',
-					'value' => $this->bytes_to_mega_html(qa_opt('wysiwyg_editor_upload_max_size')),
+					'value' => qa_html(number_format($this->bytes_to_mega(qa_opt('wysiwyg_editor_upload_max_size')))),
 					'tags' => 'name="wysiwyg_editor_upload_max_size_field"',
 				),
 			),
@@ -215,16 +215,12 @@ class qa_wysiwyg_editor
 				);
 			}
 			else {
-				// convert to text
-				$viewer = qa_load_module('viewer', '');
-
 				return array(
 					'format' => '',
 					'content' => $this->html_to_text($html),
 				);
 			}
-		}
-		else {
+		} else {
 			// CKEditor was not loaded so treat it as plain text
 			return array(
 				'format' => '',
@@ -248,8 +244,8 @@ class qa_wysiwyg_editor
 	 * @deprecated This function will become private in Q2A 1.8. It is specific to this plugin and
 	 * should not be used by outside code.
 	 */
-	public function bytes_to_mega_html($bytes)
+	public function bytes_to_mega($bytes)
 	{
-		return qa_html(number_format($bytes/1048576, 1));
+		return $bytes / 1048576;
 	}
 }

--- a/qa-theme/Snow/qa-theme.php
+++ b/qa-theme/Snow/qa-theme.php
@@ -34,6 +34,8 @@ class qa_html_theme extends qa_html_theme_base
 
 	public function logged_in()
 	{
+		require_once QA_INCLUDE_DIR . 'app/format.php';
+
 		if (qa_is_logged_in()) // output user avatar to login bar
 			$this->output(
 				'<div class="qa-logged-in-avatar">',
@@ -52,7 +54,7 @@ class qa_html_theme extends qa_html_theme_base
 
 			$pointshtml=($userpoints==1)
 				? qa_lang_html_sub('main/1_point', '1', '1')
-				: qa_lang_html_sub('main/x_points', qa_html(number_format($userpoints)));
+				: qa_lang_html_sub('main/x_points', qa_html(qa_format_number($userpoints)));
 
 			$this->output(
 				'<span class="qa-logged-in-points">',

--- a/qa-theme/SnowFlat/inc/qam-snow-theme.php
+++ b/qa-theme/SnowFlat/inc/qam-snow-theme.php
@@ -244,9 +244,11 @@ class qam_snow_theme
 	 */
 	private function user_points()
 	{
+		require_once QA_INCLUDE_DIR . 'app/format.php';
+
 		if (qa_is_logged_in()) {
 			$userpoints = qa_get_logged_in_points();
-			$pointshtml = ($userpoints == 1) ? qa_lang_html_sub('main/1_point', '1', '1') : qa_html(number_format($userpoints));
+			$pointshtml = ($userpoints == 1) ? qa_lang_html_sub('main/1_point', '1', '1') : qa_html(qa_format_number($userpoints));
 			$points     = '<DIV CLASS="qam-logged-in-points">' . $pointshtml . '</DIV>';
 
 			return $points;


### PR DESCRIPTION
Continuing with the discussion in #158.

Ok, so these are the numbers I've modified. I guess those are all. Also note this doesn't include a feature to allow all numbers to be translated because that would mean all numbers should go through this function and there are many constants (particularly, a lot of number ones used in, e.g., "1_year") that I have not included. Anyway, it is a first step towards that direction.

A related item to mention is that I noticed this construction

```php
$value == 1
   ? qa_lang_html_sub('main/1_value', '1', '1')
   : qa_lang_html_sub('main/x_value', $value)
```

is repeated too often and I think it might be better to add some `qa_lang_html_sub_one_many($value, $langStringOne, $langStringMany)` function to reuse some code.

Regarding the "compacting" of numbers I've made a list of all the numbers I've sent through this function. I think compacting them would mean sending an additional parameter to that function but each place in which they're displayed need to be analyzed whether the compacting should happen or not. In the list, I've given my opinion based on when users would like the exact number and when they won't.

Modified numbers:
 * All numbers displayed in the favorite section (user points, tag amount, questions in category count): Compact
 * Alert displayed when exceeding file size number when attaching a big file in the ckeditor: Not compact
 * Votes in questions lists: Compact
 * Number of answers in question lists: Compact
 * Number of views in questions lists and question pages: Compact
 * Amount of points displayed in the <who> section for question info. EG: "ASKED Nov 26 in Cat 1 by admin (123,716 points)": Compact
 * Amount of points displayed in the <who> section for answer, comment or edit info. EG: "ANSWERED Nov 26 in Cat 1 by admin (123,716 points)": Compact
 * Number of questions per category in the (fake) category widget: Compact
 * Number of emails sent when sending mass emails (the updated email numbers): Not compact
 * In Admin -> Categories 
   * When editing a category, the total question count: Not compact
   * When editing a category, the amount of questions for a category that have no subcategory: Not compact
   * When there are questions with no category and the setting that requires question to have a category is enabled: Not compact
 * In Admin -> Stats:
   * Database size: Not compact
   * Total questions: Not compact
   * From users: Not compact
   * From anonymouns: Not compact
   * Total answers: Not compact
   * From users: Not compact
   * From anonymouns: Not compact
   * Total comments: Not compact
   * From users: Not compact
   * From anonymouns: Not compact
   * Registered users (for internal users): Not compact
   * Active users (for external users): Not compact
   * Users who posted: Not compact
   * Users who voted: Not compact
   * When reindexing content (the updated pages, posts and words reindexed): Not compact
   * When recounting content (the votes and flags and answers and hotness recount): Not compact
   * When recalculating user points: Not compact
   * When refilling event streams: Not compact
   * When recalculating categories (): Not compact
   * When deleting hidden posts (questions, answers and comments): Not compact
   * When moving blob to disk or db: Not compact
 * In Admin -> Users when displaying points of the users' titles: Not compact
 * In categories page, the amount of questions per category: Compact
 * In tags page, the amount of questions per tag: Compact
 * In users page, the amount of points per user: Compact
 * In profile section
   * Score: Not compact
   * Questions: Not compact
   * Answers: Not compact
   * Comments: Not compact
   * Voted on questions and answers: Not compact
   * Gave out up and down votes: Not compact
   * Received up and down votes: Not compact
   * Rank: Not compact
   * Question with best answer selected: Not compact
   * Answers selected as best: Not compact
 * Activity count widget: Compact
 * Maximum file size in wysiwyg plugin options: Not compact

Regarding the setting to control whether to compact numbers or not, should it be placed at the bottom of the admin/viewing section or in any other place?

Slightly unrelated to this branch, I've also mixed a refactor of `qa_recalc_get_message` that adds a "private" function. I think it is a good way to avoid issues in global context for functions that should not be part of the core's interface. More info in this comment: https://github.com/q2a/question2answer/pull/101#issuecomment-61041024

BTW, the easy way to test this would be to multiply the number by 1000 and change the thousand and decimal keys in the language file.

Let's keep this PR open (unmerged) until it is ready so that I can rebase it freely, if needed. Thanks.