### PR TITLE
[Improvement - MED] Added a theme-dependant CSS class to the body tag

### DIFF
--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -48,7 +48,7 @@ class qa_html_theme_base
 	protected $rooturl;
 	protected $request;
 	protected $isRTL; // (boolean) whether text direction is Right-To-Left
-	protected $theme = 'default';
+	protected $theme;
 
 	// whether to use new block layout in rankings (true) or fall back to tables (false)
 	protected $ranking_block_layout = false;
@@ -405,7 +405,8 @@ class qa_html_theme_base
 
 	public function body_tags()
 	{
-		$class = sprintf('qa-theme-%s qa-template-%s', qa_html($this->theme), qa_html($this->template));
+		$class = isset($this->theme) ? 'qa-theme-' . qa_html($this->theme) . ' ' : '';
+		$class .= 'qa-template-' . qa_html($this->template);
 
 		if (isset($this->content['categoryids'])) {
 			foreach ($this->content['categoryids'] as $categoryid)

--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -48,6 +48,7 @@ class qa_html_theme_base
 	protected $rooturl;
 	protected $request;
 	protected $isRTL; // (boolean) whether text direction is Right-To-Left
+	protected $theme = 'default';
 
 	// whether to use new block layout in rankings (true) or fall back to tables (false)
 	protected $ranking_block_layout = false;
@@ -404,11 +405,11 @@ class qa_html_theme_base
 
 	public function body_tags()
 	{
-		$class = 'qa-template-'.qa_html($this->template);
+		$class = sprintf('qa-theme-%s qa-template-%s', qa_html($this->theme), qa_html($this->template));
 
 		if (isset($this->content['categoryids'])) {
 			foreach ($this->content['categoryids'] as $categoryid)
-				$class .= ' qa-category-'.qa_html($categoryid);
+				$class .= ' qa-category-' . qa_html($categoryid);
 		}
 
 		$this->output('class="'.$class.' qa-body-js-off"');

--- a/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
+++ b/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
@@ -134,7 +134,7 @@ class qa_wysiwyg_editor
 
 				// File uploads
 				($uploadimages ? "	filebrowserImageUploadUrl: $imageUploadUrl," : ""),
-				($uploadall ? "	filebrowserUploadUrl: $fileUploadUrl," : ""),
+				($uploadall ? "	filebrowserUploadUrl: $fileUploadUrl" : ""),
 
 				"};",
 			);

--- a/qa-theme/Candy/qa-theme.php
+++ b/qa-theme/Candy/qa-theme.php
@@ -25,6 +25,13 @@ class qa_html_theme extends qa_html_theme_base
 	// use new ranking layout
 	protected $ranking_block_layout = true;
 
+	public function __construct($template, $content, $rooturl, $request)
+	{
+		parent::__construct($template, $content, $rooturl, $request);
+
+		$this->theme = 'candy';
+	}
+
 	public function nav_user_search() // reverse the usual order
 	{
 		$this->search();

--- a/qa-theme/Classic/qa-theme.php
+++ b/qa-theme/Classic/qa-theme.php
@@ -24,4 +24,11 @@ class qa_html_theme extends qa_html_theme_base
 {
 	// use new ranking layout
 	protected $ranking_block_layout = true;
+
+	public function __construct($template, $content, $rooturl, $request)
+	{
+		parent::__construct($template, $content, $rooturl, $request);
+
+		$this->theme = 'classic';
+	}
 }

--- a/qa-theme/Snow/qa-theme.php
+++ b/qa-theme/Snow/qa-theme.php
@@ -5,6 +5,13 @@ class qa_html_theme extends qa_html_theme_base
 	// use new ranking layout
 	protected $ranking_block_layout = true;
 
+	public function __construct($template, $content, $rooturl, $request)
+	{
+		parent::__construct($template, $content, $rooturl, $request);
+
+		$this->theme = 'snow';
+	}
+
 	// outputs login form if user not logged in
 	public function nav_user_search()
 	{

--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -45,6 +45,8 @@ class qa_html_theme extends qa_html_theme_base
 	{
 		parent::__construct($template, $content, $rooturl, $request);
 
+		$this->theme = 'snowflat';
+
 		// theme subdirectories
 		$this->js_dir = 'js/';
 		$this->img_url = 'images/';
@@ -149,13 +151,11 @@ class qa_html_theme extends qa_html_theme_base
 	{
 		global $qam_snow;
 
-		$class = 'qa-template-' . qa_html($this->template);
+		$class = sprintf('qa-theme-%s qa-template-%s', qa_html($this->theme), qa_html($this->template));
 
 		if (isset($this->content['categoryids'])) {
 			foreach ($this->content['categoryids'] as $categoryid)
-			{
 				$class .= ' qa-category-' . qa_html($categoryid);
-			}
 		}
 
 		// add class if admin/appovoe-users page

--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -151,7 +151,8 @@ class qa_html_theme extends qa_html_theme_base
 	{
 		global $qam_snow;
 
-		$class = sprintf('qa-theme-%s qa-template-%s', qa_html($this->theme), qa_html($this->template));
+		$class = isset($this->theme) ? 'qa-theme-' . qa_html($this->theme) . ' ' : '';
+		$class .= 'qa-template-' . qa_html($this->template);
 
 		if (isset($this->content['categoryids'])) {
 			foreach ($this->content['categoryids'] as $categoryid)


### PR DESCRIPTION
The motivation of the PR is to allow plugin developers to distribute plugins that work out of the box.

Currently, each user has to configure the appropriate CSS for each theme. I decided to provide the CSS for each (popular) theme but each user has to apply it. Alternatively, each plugin developer could check the currently selected theme (by means of PHP) and select a given CSS to use. I think a better approach would be to fix a presentation issue just with CSS.

This PR sets a theme identifier (which also needs to be a valid CSS classname) to the body of the HTML document. That way each plugin developer can provide a CSS file with the general stuff (theme independent CSS) and the fixes for each (popular) theme (theme dependent CSS).

A default value should be applied in case a theme does not have an identifier configured. EG:
```
.qa-theme-snowflat .my-button {
    padding: 20px;
}

.qa-theme-default .my-button,
.qa-theme-classic .my-button {
    padding: 0px;
    margin: 10px;
}
```
The good thing is that this change is 100% backwards compatible and, speaking for myself, I would use this in each plugin that includes CSS.