### PR TITLE
Patch to core login to allow login credential check to be overridden in a plugin

### DIFF
--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -58,32 +58,20 @@
 				qa_limits_increment(null, QA_LIMIT_LOGINS);
 
 				$errors=array();
+				$res = qa_check_login_credentials($inemailhandle, $inpassword);
 
-				if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@')!==false)) // handles can't contain @ symbols
-					$matchusers=qa_db_user_find_by_email($inemailhandle);
-				else
-					$matchusers=qa_db_user_find_by_handle($inemailhandle);
+				if ($res == 0) { // login and redirect
+					$topath=qa_get('to');
 
-				if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
-					$inuserid=$matchusers[0];
-					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
+					if (isset($topath))
+						qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment
+					elseif ($passwordsent)
+						qa_redirect('account');
+					else
+						qa_redirect('');
 
-					if (strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) { // login and redirect
-						require_once QA_INCLUDE_DIR.'app/users.php';
-
-						qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
-
-						$topath=qa_get('to');
-
-						if (isset($topath))
-							qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment
-						elseif ($passwordsent)
-							qa_redirect('account');
-						else
-							qa_redirect('');
-
-					} else
-						$errors['password']=qa_lang('users/password_wrong');
+				} elseif ($res == 2) {
+					$errors['password']=qa_lang('users/password_wrong');
 
 				} else
 					$errors['emailhandle']=qa_lang('users/user_not_found');


### PR DESCRIPTION
In this patch, the core credential check functionality has been moved into a function.
This allows a plugin e.g. the ldap plugin (which I have also patched appropriately under my fork) to very simply override the credential check and login against LDAP whilst utilizing the existing login handling framework. 