### PR TITLE
[PATCH] Moved core credential check into function in app/users.php

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -225,7 +225,7 @@
 			unset($_SESSION['qa_session_verify_'.$suffix]);
 		}
 
-		function qa_check_login_credentials($inemailhandle, $inpassword)
+		function qa_check_login_credentials($inemailhandle, $inpassword, $inremember)
 	/*
 		Call to check login credentials, override in plugin for custom credential checking whilst maintaining the normal cookie handling etc.
 		returns:

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -51,6 +51,9 @@
 	@define('QA_FORM_EXPIRY_SECS', 86400); // how many seconds a form is valid for submission
 	@define('QA_FORM_KEY_LENGTH', 32);
 
+	const LOGIN_CREDENTIALS_OK = 0;
+	const LOGIN_USER_NOT_FOUND = 1;
+	const LOGIN_PASSWORD_INCORRECT = 2;
 
 	if (QA_FINAL_EXTERNAL_USERS) {
 
@@ -229,9 +232,9 @@
 	/*
 		Call to check login credentials, override in plugin for custom credential checking whilst maintaining the normal cookie handling etc.
 		returns:
-		0 == credentials OK
-		1 == user not found
-		2 == password incorrect
+		LOGIN_CREDENTIALS_OK (0) == credentials OK
+		LOGIN_USER_NOT_FOUND (1) == user not found
+		LOGIN_PASSWORD_INCORRECT (2) == password incorrect
 	*/
 		{
 			if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
@@ -247,11 +250,11 @@
 
 				if (strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) {
 					qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
-					return 0;
+					return LOGIN_CREDENTIALS_OK;
 				} else 
-					return 2;
+					return LOGIN_PASSWORD_INCORRECT;
 			}
-			return 1;
+			return LOGIN_USER_NOT_FOUND;
 		}
 		
 		function qa_set_logged_in_user($userid, $handle='', $remember=false, $source=null)

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -225,7 +225,35 @@
 			unset($_SESSION['qa_session_verify_'.$suffix]);
 		}
 
+		function qa_check_login_credentials($inemailhandle, $inpassword)
+	/*
+		Call to check login credentials, override in plugin for custom credential checking whilst maintaining the normal cookie handling etc.
+		returns:
+		0 == credentials OK
+		1 == user not found
+		2 == password incorrect
+	*/
+		{
+			if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
+			if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@')!==false)) // handles can't contain @ symbols
+				$matchusers=qa_db_user_find_by_email($inemailhandle);
+			else
+				$matchusers=qa_db_user_find_by_handle($inemailhandle);
+
+			if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
+				$inuserid=$matchusers[0];
+				$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
+
+				if (strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) {
+					qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
+					return 0;
+				} else 
+					return 2;
+			}
+			return 1;
+		}
+		
 		function qa_set_logged_in_user($userid, $handle='', $remember=false, $source=null)
 	/*
 		Call for successful log in by $userid and $handle or successful log out with $userid=null.

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -60,7 +60,7 @@
 				$errors=array();
 				$res = qa_check_login_credentials($inemailhandle, $inpassword, $inremember);
 
-				if ($res == 0) { // login and redirect
+				if ($res == LOGIN_CREDENTIALS_OK) { // login and redirect
 					$topath=qa_get('to');
 
 					if (isset($topath))
@@ -70,7 +70,7 @@
 					else
 						qa_redirect('');
 
-				} elseif ($res == 2) {
+				} elseif ($res == LOGIN_PASSWORD_INCORRECT) {
 					$errors['password']=qa_lang('users/password_wrong');
 
 				} else

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -58,32 +58,20 @@
 				qa_limits_increment(null, QA_LIMIT_LOGINS);
 
 				$errors=array();
+				$res = qa_check_login_credentials($inemailhandle, $inpassword);
 
-				if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@')!==false)) // handles can't contain @ symbols
-					$matchusers=qa_db_user_find_by_email($inemailhandle);
-				else
-					$matchusers=qa_db_user_find_by_handle($inemailhandle);
+				if ($res == 0) { // login and redirect
+					$topath=qa_get('to');
 
-				if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
-					$inuserid=$matchusers[0];
-					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
+					if (isset($topath))
+						qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment
+					elseif ($passwordsent)
+						qa_redirect('account');
+					else
+						qa_redirect('');
 
-					if (strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) { // login and redirect
-						require_once QA_INCLUDE_DIR.'app/users.php';
-
-						qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
-
-						$topath=qa_get('to');
-
-						if (isset($topath))
-							qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment
-						elseif ($passwordsent)
-							qa_redirect('account');
-						else
-							qa_redirect('');
-
-					} else
-						$errors['password']=qa_lang('users/password_wrong');
+				} elseif ($res == 2) {
+					$errors['password']=qa_lang('users/password_wrong');
 
 				} else
 					$errors['emailhandle']=qa_lang('users/user_not_found');

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -58,7 +58,7 @@
 				qa_limits_increment(null, QA_LIMIT_LOGINS);
 
 				$errors=array();
-				$res = qa_check_login_credentials($inemailhandle, $inpassword);
+				$res = qa_check_login_credentials($inemailhandle, $inpassword, $inremember);
 
 				if ($res == 0) { // login and redirect
 					$topath=qa_get('to');


### PR DESCRIPTION
The intention of this patch is to refactor the core login credential check into a function.
This in turn allows a plugin to override the check and provide different / extended functionality.
This is particularly useful in the case of the LDAP plugin (to which I am a contributor).
Previously the plugin could only be installed via a modification to a core page. Now the plugin can simply override the credential check function and hook the LDAP credential check process into the core login framework seamlessly.
