### PR TITLE
[Bugfix - MED] Unable to recategorize closed questions

### DIFF
--- a/qa-include/pages/question-post.php
+++ b/qa-include/pages/question-post.php
@@ -458,13 +458,19 @@
 		else {
 			$in['queued']=qa_opt('moderate_edited_again') && qa_user_moderation_reason($userlevel);
 
-			$filtermodules=qa_load_modules_with('filter', 'filter_question');
-			foreach ($filtermodules as $filtermodule) {
-				$oldin=$in;
-				$filtermodule->filter_question($in, $errors, $question);
-
-				if ($question['editable'])
-					qa_update_post_text($in, $oldin);
+			if ($question['closed']) {
+				$filtermodules = qa_load_modules_with('filter', 'filter_recategorized_question');
+				foreach ($filtermodules as $filtermodule) {
+					$filtermodule->filter_recategorized_question($in, $errors);
+				}
+			} else {
+				$filtermodules=qa_load_modules_with('filter', 'filter_question');
+				foreach ($filtermodules as $filtermodule) {
+					$oldin=$in;
+					$filtermodule->filter_question($in, $errors, $question);
+					if ($question['editable'])
+						qa_update_post_text($in, $oldin);
+				}
 			}
 
 			if (array_key_exists('categoryid', $in) && strcmp($in['categoryid'], $question['categoryid']))

--- a/qa-include/plugins/qa-filter-basic.php
+++ b/qa-include/plugins/qa-filter-basic.php
@@ -58,19 +58,14 @@ class qa_filter_basic
 
 		$this->validate_length($errors, 'content', @$question['text'], qa_opt('min_len_q_content'), null); // for display
 
-		if (isset($question['tags'])) {
-			$counttags=count($question['tags']);
-			$mintags=min(qa_opt('min_num_q_tags'), qa_opt('max_num_q_tags'));
-
-			if ($counttags<$mintags)
-				$errors['tags']=qa_lang_sub('question/min_tags_x', $mintags);
-			elseif ($counttags>qa_opt('max_num_q_tags'))
-				$errors['tags']=qa_lang_sub('question/max_tags_x', qa_opt('max_num_q_tags'));
-			else
-				$this->validate_length($errors, 'tags', qa_tags_to_tagstring($question['tags']), 0, QA_DB_MAX_TAGS_LENGTH); // for storage
-		}
+		$this->filter_question_tags($question, $errors);
 
 		$this->validate_post_email($errors, $question);
+	}
+
+	public function filter_recategorized_question(&$question, &$errors)
+	{
+		$this->filter_question_tags($question, $errors);
 	}
 
 	public function filter_answer(&$answer, &$errors, $question, $oldanswer)
@@ -124,6 +119,21 @@ class qa_filter_basic
 			$error=$this->filter_email($post['email'], null);
 			if (isset($error))
 				$errors['email']=$error;
+		}
+	}
+
+	private function filter_question_tags(&$question, &$errors)
+	{
+		if (isset($question['tags'])) {
+			$counttags=count($question['tags']);
+			$mintags=min(qa_opt('min_num_q_tags'), qa_opt('max_num_q_tags'));
+
+			if ($counttags<$mintags)
+				$errors['tags']=qa_lang_sub('question/min_tags_x', $mintags);
+			elseif ($counttags>qa_opt('max_num_q_tags'))
+				$errors['tags']=qa_lang_sub('question/max_tags_x', qa_opt('max_num_q_tags'));
+			else
+				$this->validate_length($errors, 'tags', qa_tags_to_tagstring($question['tags']), 0, QA_DB_MAX_TAGS_LENGTH); // for storage
 		}
 	}
 }


### PR DESCRIPTION
If a question is closed and there is a limit in the amount of characters a question can have in the title or in the content then it can't be recategorized.

The commit to blame is this one: 3891fdd8fd72542c8247fa7b58a98f37dfd13d0e

Now, considering different validation rules apply to questions that are closed and to questions that are open, I thought on splitting the logic and the validation of fields. This results in the closed question not having their title and content fields validated.

Note the [filter module](http://www.question2answer.org/modules.php?module=filter) documentation should be updated.