### PR TITLE
[Improvements - MED] Approach to remove global variables and to enable safe mode

### DIFF
--- a/qa-include/Q2A/Application.php
+++ b/qa-include/Q2A/Application.php
@@ -5,7 +5,7 @@
   http://www.question2answer.org/
 
   File: qa-include/Q2A/Application.php
-  Description: Contains configuration data of Q2A
+  Description: Contains configuration and cache data of Q2A
 
 
   This program is free software; you can redistribute it and/or
@@ -24,6 +24,7 @@
 class Q2A_Application {
 
 	private $config;
+	private $cache;
 	private static $instance;
 
 	/**
@@ -42,6 +43,7 @@ class Q2A_Application {
 	 */
 	private function __construct() {
 		$this->config = new Q2A_Util_Set();
+		$this->cache = new Q2A_Util_Set();
 
 		$this->config->set('safe_mode', false);
 	}
@@ -66,6 +68,28 @@ class Q2A_Application {
 	 */
 	public function setConfig($key, $value) {
 		$this->config->set($key, $value);
+	}
+
+	/**
+	 * Return a value from the ache set using a default value, if provided
+	 * @param mixed $key The key that will be used to search the cache set for
+	 * @param mixed $defaultValue A default value returned if the requested key does not exist in
+	 * the cache set
+	 * @return mixed The value corresponding to the requested key or $defaultValue if the key
+	 * does not exist. If the key does not exist and the default value is not set then a null
+	 * value is returned
+	 */
+	public function getCache($key, $defaultValue = null) {
+		return $this->cache->get($key, $defaultValue);
+	}
+
+	/**
+	 * Sets a key or value to the cache set. If the value already exists, it is replaced
+	 * @param mixed $key The key that will be used to search the cache set for
+	 * @param mixed $value The value for the key
+	 */
+	public function setCache($key, $value) {
+		$this->cache->set($key, $value);
 	}
 
 }

--- a/qa-include/Q2A/Application.php
+++ b/qa-include/Q2A/Application.php
@@ -46,6 +46,8 @@ class Q2A_Application {
 		$this->cache = new Q2A_Util_Set();
 
 		$this->config->set('safe_mode', false);
+
+		$this->cache->set('layers', array());
 	}
 
 	/**

--- a/qa-include/Q2A/Application.php
+++ b/qa-include/Q2A/Application.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+  Question2Answer by Gideon Greenspan and contributors
+  http://www.question2answer.org/
+
+  File: qa-include/Q2A/Application.php
+  Description: Contains configuration data of Q2A
+
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  More about this license: http://www.question2answer.org/license.php
+ */
+
+class Q2A_Application {
+
+	private $config;
+	private static $instance;
+
+	/**
+	 * Return the singleton instance of the Q2A application
+	 * @return The Q2A application instance
+	 */
+	public static function getInstance() {
+		if (!isset(self::$instance)) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Creates a new instance of this class setting some default values
+	 */
+	private function __construct() {
+		$this->config = new Q2A_Util_Set();
+
+		$this->config->set('safe_mode', false);
+	}
+
+	/**
+	 * Return a value from the configuration set using a default value, if provided
+	 * @param mixed $key The key that will be used to search the configuration set for
+	 * @param mixed $defaultValue A default value returned if the requested key does not exist in
+	 * the configuration set
+	 * @return mixed The value corresponding to the requested key or $defaultValue if the key
+	 * does not exist. If the key does not exist and the default value is not set then a null
+	 * value is returned
+	 */
+	public function getConfig($key, $defaultValue = null) {
+		return $this->config->get($key, $defaultValue);
+	}
+
+	/**
+	 * Sets a key or value to the configuration set. If the value already exists, it is replaced
+	 * @param mixed $key The key that will be used to search the configuration set for
+	 * @param mixed $key The value for the key
+	 */
+	public function setConfig($key, $value) {
+		$this->config->set($key, $value);
+	}
+
+}

--- a/qa-include/Q2A/Application.php
+++ b/qa-include/Q2A/Application.php
@@ -48,6 +48,7 @@ class Q2A_Application {
 		$this->config->set('safe_mode', false);
 
 		$this->cache->set('layers', array());
+		$this->cache->set('notifications_suspended', 0);
 	}
 
 	/**

--- a/qa-include/Q2A/Util/Set.php
+++ b/qa-include/Q2A/Util/Set.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+  Question2Answer by Gideon Greenspan and contributors
+  http://www.question2answer.org/
+
+  File: qa-include/Q2A/Util/Set.php
+  Description: Simple and efficient set implementation
+
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  More about this license: http://www.question2answer.org/license.php
+ */
+
+class Q2A_Util_Set {
+
+	private $data = array();
+
+	/**
+	 * Return a value from the set using a default value, if provided
+	 * @param mixed $key The key that will be used to search the set for
+	 * @param mixed $defaultValue A default value returned if the requested key does not exist in
+	 * the set
+	 * @return mixed The value corresponding to the requested key or $defaultValue if the key
+	 * does not exist. If the key does not exist and the default value is not set then a null
+	 * value is returned
+	 */
+	public function get($key, $defaultValue = null) {
+		if (isset($this->data[$key]))
+			return $this->data[$key];
+		else
+			return isset($defaultValue) ? $defaultValue : null;
+	}
+
+	/**
+	 * Sets a key or value to the set. If the value already exists, it is replaced
+	 * @param mixed $key The key that will be used to search the sety for
+	 * @param mixed $value The value for the key
+	 */
+	public function set($key, $value) {
+		$this->data[$key] = $value;
+	}
+
+	/**
+	 * Checks if a key is present in the set
+	 * @param mixed $key The key that will be used to search the sety for
+	 * @return bool True if the key exists or false if the key does not exist in the set
+	 */
+	public function contains($key) {
+		return isset($this->data[$key]);
+	}
+
+}

--- a/qa-include/app/emails.php
+++ b/qa-include/app/emails.php
@@ -34,9 +34,9 @@
 	reinstate it. A counter is kept to allow multiple calls.
 */
 	{
-		global $qa_notifications_suspended;
-
-		$qa_notifications_suspended+=($suspend ? 1 : -1);
+		$notifications_suspended = Q2A_Application::getInstance()->getCache('notifications_suspended');
+		$notifications_suspended += $suspend ? 1 : -1;
+		Q2A_Application::getInstance()->setCache('notifications_suspended', $notifications_suspended);
 	}
 
 
@@ -49,9 +49,9 @@
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-		global $qa_notifications_suspended;
+		$notifications_suspended = Q2A_Application::getInstance()->getCache('notifications_suspended');
 
-		if ($qa_notifications_suspended>0)
+		if ($notifications_suspended > 0)
 			return false;
 
 		require_once QA_INCLUDE_DIR.'db/selects.php';

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1745,7 +1745,7 @@
 
 	//	Then load the selected theme if valid, otherwise load the Classic theme
 
-		if (!file_exists(QA_THEME_DIR.$theme.'/qa-styles.css'))
+		if (!file_exists(QA_THEME_DIR.$theme.'/qa-styles.css') || Q2A_Application::getInstance()->getConfig('safe_mode'))
 			$theme='Classic';
 
 		$themeroothtml=qa_html(qa_path_to_root().'qa-theme/'.$theme.'/');

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1735,7 +1735,6 @@
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-		global $qa_layers;
 
 	//	First load the default class
 
@@ -1759,7 +1758,7 @@
 
 	//	Create the list of layers to load
 
-		$loadlayers=$qa_layers;
+		$loadlayers = Q2A_Application::getInstance()->getCache('layers');
 
 		if (!qa_user_maximum_permit_error('permit_view_voters_flaggers'))
 			$loadlayers[]=array(

--- a/qa-include/lang/qa-lang-admin.php
+++ b/qa-include/lang/qa-lang-admin.php
@@ -224,6 +224,7 @@
 		'reset_options_button' => 'Reset to Defaults',
 		'reset_options_confirm' => 'Are you sure you want to reset all options on this page to their defaults?',
 		'resume_mailing_button' => 'Resume Mailing',
+		'safe_mode_all_plugins_disabled' => 'All plugins are disabled in safe mode',
 		'save_options_button' => 'Save Options',
 		'save_recalc_button' => 'Save and Recalculate',
 		'save_view_button' => 'Save and View',

--- a/qa-include/pages/admin/admin-plugins.php
+++ b/qa-include/pages/admin/admin-plugins.php
@@ -69,153 +69,157 @@
 
 	$qa_content['script_rel'][] = 'qa-content/qa-admin.js?'.QA_VERSION;
 
-	$pluginfiles = glob(QA_PLUGIN_DIR.'*/qa-plugin.php');
+	if (Q2A_Application::getInstance()->getConfig('safe_mode'))
+		$qa_content['error'] = qa_lang_html('admin/safe_mode_all_plugins_disabled');
+	else {
+		$pluginfiles = glob(QA_PLUGIN_DIR.'*/qa-plugin.php');
 
-	foreach ($moduletypes as $type) {
-		$modules = qa_load_modules_with($type, 'init_queries');
+		foreach ($moduletypes as $type) {
+			$modules = qa_load_modules_with($type, 'init_queries');
 
-		foreach ($modules as $name => $module) {
-			$queries = $module->init_queries($tables);
+			foreach ($modules as $name => $module) {
+				$queries = $module->init_queries($tables);
 
-			if (!empty($queries)) {
-				if (qa_is_http_post())
-					qa_redirect('install');
+				if (!empty($queries)) {
+					if (qa_is_http_post())
+						qa_redirect('install');
 
-				else {
-					$qa_content['error'] = strtr(qa_lang_html('admin/module_x_database_init'), array(
-						'^1' => qa_html($name),
-						'^2' => qa_html($type),
-						'^3' => '<a href="'.qa_path_html('install').'">',
-						'^4' => '</a>',
-					));
+					else {
+						$qa_content['error'] = strtr(qa_lang_html('admin/module_x_database_init'), array(
+							'^1' => qa_html($name),
+							'^2' => qa_html($type),
+							'^3' => '<a href="'.qa_path_html('install').'">',
+							'^4' => '</a>',
+						));
+					}
 				}
 			}
 		}
-	}
 
-	if ( qa_is_http_post() && !qa_check_form_security_code('admin/plugins', qa_post_text('qa_form_security_code')) ) {
-		$qa_content['error'] = qa_lang_html('misc/form_security_reload');
-		$showpluginforms = false;
-	}
-	else
-		$showpluginforms = true;
-
-	if (!empty($pluginfiles)) {
-		$metadataUtil = new Q2A_Util_Metadata();
-		$sortedPluginFiles = array();
-
-		foreach ($pluginfiles as $pluginFile) {
-			$metadata = $metadataUtil->fetchFromAddonPath(dirname($pluginFile));
-			if (empty($metadata)) {
-				// limit plugin parsing to first 8kB
-				$contents = file_get_contents($pluginFile, false, null, -1, 8192);
-				$metadata = qa_addon_metadata($contents, 'Plugin');
-			}
-			$metadata['name'] = isset($metadata['name']) && !empty($metadata['name'])
-				? qa_html($metadata['name'])
-				: qa_lang_html('admin/unnamed_plugin')
-			;
-			$sortedPluginFiles[$pluginFile] = $metadata;
+		if ( qa_is_http_post() && !qa_check_form_security_code('admin/plugins', qa_post_text('qa_form_security_code')) ) {
+			$qa_content['error'] = qa_lang_html('misc/form_security_reload');
+			$showpluginforms = false;
 		}
+		else
+			$showpluginforms = true;
 
-		qa_sort_by($sortedPluginFiles, 'name');
+		if (!empty($pluginfiles)) {
+			$metadataUtil = new Q2A_Util_Metadata();
+			$sortedPluginFiles = array();
 
-		$pluginIndex = -1;
-		foreach ($sortedPluginFiles as $pluginFile => $metadata) {
-			$pluginIndex++;
-			$plugindirectory = dirname($pluginFile);
-			$hash = qa_admin_plugin_directory_hash($plugindirectory);
-			$showthisform = $showpluginforms && (qa_get('show') == $hash);
-
-			$namehtml = $metadata['name'];
-
-			if (isset($metadata['uri']) && strlen($metadata['uri']))
-				$namehtml = '<a href="'.qa_html($metadata['uri']).'">'.$namehtml.'</a>';
-
-			$namehtml = '<b>'.$namehtml.'</b>';
-
-			$metaver = isset($metadata['version']) && strlen($metadata['version']);
-			if ($metaver)
-				$namehtml .= ' v'.qa_html($metadata['version']);
-
-			if (isset($metadata['author']) && strlen($metadata['author'])) {
-				$authorhtml = qa_html($metadata['author']);
-
-				if (isset($metadata['author_uri']) && strlen($metadata['author_uri']))
-					$authorhtml = '<a href="'.qa_html($metadata['author_uri']).'">'.$authorhtml.'</a>';
-
-				$authorhtml = qa_lang_html_sub('main/by_x', $authorhtml);
-
+			foreach ($pluginfiles as $pluginFile) {
+				$metadata = $metadataUtil->fetchFromAddonPath(dirname($pluginFile));
+				if (empty($metadata)) {
+					// limit plugin parsing to first 8kB
+					$contents = file_get_contents($pluginFile, false, null, -1, 8192);
+					$metadata = qa_addon_metadata($contents, 'Plugin');
+				}
+				$metadata['name'] = isset($metadata['name']) && !empty($metadata['name'])
+					? qa_html($metadata['name'])
+					: qa_lang_html('admin/unnamed_plugin')
+				;
+				$sortedPluginFiles[$pluginFile] = $metadata;
 			}
-			else
-				$authorhtml = '';
 
-			if ($metaver && isset($metadata['update_uri']) && strlen($metadata['update_uri'])) {
-				$elementid = 'version_check_'.md5($plugindirectory);
+			qa_sort_by($sortedPluginFiles, 'name');
 
-				$updatehtml = '(<span id="'.$elementid.'">...</span>)';
+			$pluginIndex = -1;
+			foreach ($sortedPluginFiles as $pluginFile => $metadata) {
+				$pluginIndex++;
+				$plugindirectory = dirname($pluginFile);
+				$hash = qa_admin_plugin_directory_hash($plugindirectory);
+				$showthisform = $showpluginforms && (qa_get('show') == $hash);
 
-				$qa_content['script_onloads'][] = array(
-					"qa_version_check(".qa_js($metadata['update_uri']).", ".qa_js($metadata['version'], true).", ".qa_js($elementid).");"
+				$namehtml = $metadata['name'];
+
+				if (isset($metadata['uri']) && strlen($metadata['uri']))
+					$namehtml = '<a href="'.qa_html($metadata['uri']).'">'.$namehtml.'</a>';
+
+				$namehtml = '<b>'.$namehtml.'</b>';
+
+				$metaver = isset($metadata['version']) && strlen($metadata['version']);
+				if ($metaver)
+					$namehtml .= ' v'.qa_html($metadata['version']);
+
+				if (isset($metadata['author']) && strlen($metadata['author'])) {
+					$authorhtml = qa_html($metadata['author']);
+
+					if (isset($metadata['author_uri']) && strlen($metadata['author_uri']))
+						$authorhtml = '<a href="'.qa_html($metadata['author_uri']).'">'.$authorhtml.'</a>';
+
+					$authorhtml = qa_lang_html_sub('main/by_x', $authorhtml);
+
+				}
+				else
+					$authorhtml = '';
+
+				if ($metaver && isset($metadata['update_uri']) && strlen($metadata['update_uri'])) {
+					$elementid = 'version_check_'.md5($plugindirectory);
+
+					$updatehtml = '(<span id="'.$elementid.'">...</span>)';
+
+					$qa_content['script_onloads'][] = array(
+						"qa_version_check(".qa_js($metadata['update_uri']).", ".qa_js($metadata['version'], true).", ".qa_js($elementid).");"
+					);
+
+				}
+				else
+					$updatehtml = '';
+
+				if (isset($metadata['description']))
+					$deschtml = qa_html($metadata['description']);
+				else
+					$deschtml = '';
+
+				if (isset($pluginoptionmodules[$plugindirectory]) && !$showthisform)
+					$deschtml .= (strlen($deschtml) ? ' - ' : '').'<a href="'.
+						qa_admin_plugin_options_path($plugindirectory).'">'.qa_lang_html('admin/options').'</a>';
+
+				$pluginhtml = $namehtml.' '.$authorhtml.' '.$updatehtml.'<br>'.$deschtml.(strlen($deschtml) ? '<br>' : '').
+					'<small style="color:#666">'.qa_html($plugindirectory).'/</small>';
+
+				if (qa_qa_version_below(@$metadata['min_q2a']))
+					$pluginhtml = '<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
+						qa_lang_html_sub('admin/requires_q2a_version', qa_html($metadata['min_q2a'])).'</span>';
+
+				elseif (qa_php_version_below(@$metadata['min_php']))
+					$pluginhtml = '<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
+						qa_lang_html_sub('admin/requires_php_version', qa_html($metadata['min_php'])).'</span>';
+
+				$qa_content['form_plugin_'.$pluginIndex] = array(
+					'tags' => 'id="'.qa_html($hash).'"',
+					'style' => 'tall',
+					'fields' => array(
+						array(
+							'type' => 'custom',
+							'html' => $pluginhtml,
+						)
+					),
 				);
 
+				if ($showthisform && isset($pluginoptionmodules[$plugindirectory]))
+					foreach ($pluginoptionmodules[$plugindirectory] as $pluginoptionmodule) {
+						$type = $pluginoptionmodule['type'];
+						$name = $pluginoptionmodule['name'];
+
+						$module = qa_load_module($type, $name);
+
+						$form = $module->admin_form($qa_content);
+
+						if (!isset($form['tags']))
+							$form['tags'] = 'method="post" action="'.qa_admin_plugin_options_path($plugindirectory).'"';
+
+						if (!isset($form['style']))
+							$form['style'] = 'tall';
+
+						$form['boxed'] = true;
+
+						$form['hidden']['qa_form_security_code'] = qa_get_form_security_code('admin/plugins');
+
+						$qa_content['form_plugin_options'] = $form;
+					}
+
 			}
-			else
-				$updatehtml = '';
-
-			if (isset($metadata['description']))
-				$deschtml = qa_html($metadata['description']);
-			else
-				$deschtml = '';
-
-			if (isset($pluginoptionmodules[$plugindirectory]) && !$showthisform)
-				$deschtml .= (strlen($deschtml) ? ' - ' : '').'<a href="'.
-					qa_admin_plugin_options_path($plugindirectory).'">'.qa_lang_html('admin/options').'</a>';
-
-			$pluginhtml = $namehtml.' '.$authorhtml.' '.$updatehtml.'<br>'.$deschtml.(strlen($deschtml) ? '<br>' : '').
-				'<small style="color:#666">'.qa_html($plugindirectory).'/</small>';
-
-			if (qa_qa_version_below(@$metadata['min_q2a']))
-				$pluginhtml = '<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
-					qa_lang_html_sub('admin/requires_q2a_version', qa_html($metadata['min_q2a'])).'</span>';
-
-			elseif (qa_php_version_below(@$metadata['min_php']))
-				$pluginhtml = '<strike style="color:#999">'.$pluginhtml.'</strike><br><span style="color:#f00">'.
-					qa_lang_html_sub('admin/requires_php_version', qa_html($metadata['min_php'])).'</span>';
-
-			$qa_content['form_plugin_'.$pluginIndex] = array(
-				'tags' => 'id="'.qa_html($hash).'"',
-				'style' => 'tall',
-				'fields' => array(
-					array(
-						'type' => 'custom',
-						'html' => $pluginhtml,
-					)
-				),
-			);
-
-			if ($showthisform && isset($pluginoptionmodules[$plugindirectory]))
-				foreach ($pluginoptionmodules[$plugindirectory] as $pluginoptionmodule) {
-					$type = $pluginoptionmodule['type'];
-					$name = $pluginoptionmodule['name'];
-
-					$module = qa_load_module($type, $name);
-
-					$form = $module->admin_form($qa_content);
-
-					if (!isset($form['tags']))
-						$form['tags'] = 'method="post" action="'.qa_admin_plugin_options_path($plugindirectory).'"';
-
-					if (!isset($form['style']))
-						$form['style'] = 'tall';
-
-					$form['boxed'] = true;
-
-					$form['hidden']['qa_form_security_code'] = qa_get_form_security_code('admin/plugins');
-
-					$qa_content['form_plugin_options'] = $form;
-				}
-
 		}
 	}
 

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -332,6 +332,9 @@
 	Load all the qa-plugin.php files from plugins that are compatible with this version of Q2A
 */
 	{
+		if (Q2A_Application::getInstance()->getConfig('safe_mode'))
+			return;
+
 		global $qa_plugin_directory, $qa_plugin_urltoroot;
 
 		$pluginfiles = glob(QA_PLUGIN_DIR.'*/qa-plugin.php');

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -260,10 +260,9 @@
 	Gets everything ready to start using modules, layers and overrides
 */
 	{
-		global $qa_modules, $qa_layers, $qa_override_files, $qa_overrides, $qa_direct;
+		global $qa_modules, $qa_override_files, $qa_overrides, $qa_direct;
 
 		$qa_modules=array();
-		$qa_layers=array();
 		$qa_override_files=array();
 		$qa_overrides=array();
 		$qa_direct=array();
@@ -446,19 +445,21 @@
 	pass in the local plugin $directory and the $urltoroot relative url for that directory
 */
 	{
-		global $qa_layers;
+		$layers = Q2A_Application::getInstance()->getCache('layers');
 
-		$previous=@$qa_layers[$name];
-
-		if (isset($previous))
+		if (isset($layers[$name])) {
+			$previous = $layers[$name];
 			qa_fatal_error('A layer named '.$name.' already exists. Please check there are no duplicate plugins. '.
 				"\n\nLayer 1: ".$previous['directory'].$previous['include']."\nLayer 2: ".$directory.$include);
+		}
 
-		$qa_layers[$name]=array(
+		$layers[$name]=array(
 			'directory' => $directory,
 			'urltoroot' => $urltoroot,
 			'include' => $include,
 		);
+
+		Q2A_Application::getInstance()->setCache('layers', $layers);
 	}
 
 


### PR DESCRIPTION
Just throwing some ideas about configuration management and cache storage.

I thought this could be a feasible approach to get rid of global variables as well as providing a way to change configurations to execute test cases. Currently, it is not possible to create a test a of a function that queries a constant (e.g.: checking for external users) as the constant can't be changed. Having the ability to change those constants allows tests to be created. Or maybe there is another way to workaround this that I couldn't figure out.

Note that although the "global" keyword is gone, a "global" context is still used.

Regarding safe mode, it is just an excuse to see how this approach works, but probably might be useful anyway.

PS: To better see the diff in admin-plugins.php it's better to perform a `git diff -w`
