### PR TITLE
[Bugfix - LOW] Removed the Search text from the input search button

### DIFF
--- a/qa-plugin/tag-cloud-widget/qa-tag-cloud.php
+++ b/qa-plugin/tag-cloud-widget/qa-tag-cloud.php
@@ -135,7 +135,7 @@ class qa_tag_cloud
 				} else
 					$size = $maxsize;
 
-				$themeobject->output(sprintf('<a href="%s" style="font-size: %dpx; vertical-align: baseline;">%s</a>', qa_path_html('tag/' . $tag), $size, qa_html($tag)));
+				$themeobject->output(sprintf('<a href="%s" style="font-size: %dpx; vertical-align: baseline;" class="qa-tag-link">%s</a>', qa_path_html('tag/' . $tag), $size, qa_html($tag)));
 			}
 		}
 

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -190,17 +190,18 @@ blockquote p {
 	padding: 8px;
 	margin-bottom: 5px;
 	background: #bdc3c7;
+	font-size: 0;
 }
 
 .qa-search-field {
-	margin: 0 -40px 0 0;
-	padding: 0 40px 0 0;
+	margin: 0 -36px 0 0;
 	vertical-align: bottom;
 	width: 100%;
 	height: 36px;
 	border-width: 1px;
 	border-style: solid;
 	border-color: transparent;
+	font-size: 14px;
 }
 .qa-search-field:focus {
 	border-color: #e6e6e6;
@@ -212,9 +213,8 @@ blockquote p {
 	background-position: center;
 	background-repeat: no-repeat;
 	height: 36px;
-	text-indent: 9999px;
 	width: 36px;
-	margin: 0 !important;
+	margin: 0;
 	border: none;
 	outline: none;
 }

--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -670,4 +670,17 @@ class qa_html_theme extends qa_html_theme_base
 			'</div>';
 	}
 
+	/**
+	 * Used to remove the search button label
+	 *
+	 * @since Snow 1.4
+	 * @version 1.0
+	 * @return string Ask button html markup
+	 */
+	public function search_button($search)
+	{
+		$search['button_label'] = '';
+		parent::search_button($search);
+	}
+
 }


### PR DESCRIPTION
I don't really like this approach but as long as there is a blank character between those 2 inputs any approach would be a mess. With this one, at least, you forget about the width of the blank character between the inputs.