### PR TITLE
[Bugfix - LOW] Corrected a bug that bypassed checking the allow_multi_answers option when posting

### DIFF
--- a/qa-include/pages/question-submit.php
+++ b/qa-include/pages/question-submit.php
@@ -353,6 +353,16 @@
 			}
 
 			if (empty($errors)) {
+				// Makes sure users don't add more than one answer when allow_multi_answers is off
+				require_once QA_INCLUDE_DIR . 'pages/question-view.php';
+
+				$rules = qa_page_q_post_rules($question, null, null, $answers);
+
+				if (!$rules['answerbutton'])
+					$errors[] = '';  // Error is not displayed because the component won't be displayed
+			}
+
+			if (empty($errors)) {
 				$userid=qa_get_logged_in_userid();
 				$handle=qa_get_logged_in_handle();
 				$cookieid=isset($userid) ? qa_cookie_get() : qa_cookie_get_create(); // create a new cookie if necessary


### PR DESCRIPTION
How to reproduce the issue:

1.  Disable the `allow_multi_answers` setting
1.  Open a question that has no answer for your current user in 2 separate tabs
1.  Post an answer in one tab
1.  Post an answer in the other tab

Expected result: The answer is not posted
Actual result: :boom: 

Although this issue is actually related to the model rather than the view, the current design is focused on the view and whether visual components, such as buttons, should be displayed or not. So in order not to reinvent the will for a simple bugfix I think the best approach would be to take that business logic from the view handling functions.