### PR TITLE
[Theme] Removed the link styling from the categories in the level user profile field

### DIFF
--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -2036,7 +2036,7 @@ input[type="submit"], button {
 	margin-top: 0;
 }
 
-#level .qa-form-wide-static a {
+#level .qa-form-wide-static a:first-child {
 	background-color: #27ae60;
 	background-image: url('images/icons/mail-white.png');
 	background-repeat: no-repeat;
@@ -2046,7 +2046,7 @@ input[type="submit"], button {
 	display: inline-block;
 	color: #fff;
 }
-#level .qa-form-wide-static a:hover, #level .qa-form-wide-static a:focus {
+#level .qa-form-wide-static a:hover:first-child, #level .qa-form-wide-static a:focus:first-child {
 	background-color: #2ecc71;
 	background-image: url('images/icons/mail-white.png');
 	border: 1px solid #25a25a;


### PR DESCRIPTION
The `#level` field in the user profile takes the styling of the private message link to all the links inside, including the category-specific ones:

![download](https://cloud.githubusercontent.com/assets/1449790/7785156/42ac5048-0159-11e5-824c-efaac1e60c6c.jpg)

Alternatively, the whole "button styling" could be removed and keep them all as links.
More alternatively, the way of contacting a user should not be in the level field. It seems it ended up there just because there was some space available.