### PR TITLE
[Refactor] Turned all REPLACE statements into INSERT..ON DUPLICATE KEY UPDATE

### DIFF
--- a/qa-include/db/cache.php
+++ b/qa-include/db/cache.php
@@ -41,7 +41,8 @@
 		);
 
 		qa_db_query_sub(
-			'REPLACE ^cache (type, cacheid, content, created, lastread) VALUES ($, #, $, NOW(), NOW())',
+			'INSERT INTO ^cache (type, cacheid, content, created, lastread) VALUES ($, #, $, NOW(), NOW()) ' .
+			'ON DUPLICATE KEY UPDATE content = VALUES(content), created = VALUES(created), lastread = VALUES(lastread)',
 			$type, $cacheid, $content
 		);
 	}

--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -595,7 +595,11 @@
 	Set the current version in the database
 */
 	{
-		qa_db_query_sub("REPLACE ^options (title,content) VALUES ('db_version', #)", $version);
+		qa_db_query_sub(
+			"INSERT INTO ^options (title, content) VALUES ('db_version', #) " .
+			"ON DUPLICATE KEY UPDATE content = VALUES(content)",
+			$version
+		);
 	}
 
 

--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -595,11 +595,9 @@
 	Set the current version in the database
 */
 	{
-		qa_db_query_sub(
-			"INSERT INTO ^options (title, content) VALUES ('db_version', #) " .
-			"ON DUPLICATE KEY UPDATE content = VALUES(content)",
-			$version
-		);
+		require_once QA_INCLUDE_DIR . 'db/options.php';
+
+		qa_db_set_option('db_version', $version);
 	}
 
 

--- a/qa-include/db/metas.php
+++ b/qa-include/db/metas.php
@@ -144,7 +144,8 @@
 */
 	{
 		qa_db_query_sub(
-			'REPLACE ^'.$metatable.' ('.$idcolumn.', title, content) VALUES ($, $, $)',
+			'INSERT INTO ^' . $metatable . ' (' . $idcolumn . ', title, content) VALUES ($, $, $) ' .
+			'ON DUPLICATE KEY UPDATE content = VALUES(content)',
 			$idvalue, $title, $content
 		);
 	}

--- a/qa-include/db/options.php
+++ b/qa-include/db/options.php
@@ -32,7 +32,8 @@
 */
 	{
 		qa_db_query_sub(
-			'REPLACE ^options (title, content) VALUES ($, $)',
+			'INSERT INTO ^options (title, content) VALUES ($, $) ' .
+			'ON DUPLICATE KEY UPDATE content = VALUES(content)',
 			$name, $value
 		);
 	}

--- a/qa-include/db/points.php
+++ b/qa-include/db/points.php
@@ -208,8 +208,13 @@
 	Update the cached count in the database of the number of rows in the userpoints table
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_userpointscount', COUNT(*) FROM ^userpoints");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_userpointscount', COUNT(*) FROM ^userpoints " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 

--- a/qa-include/db/post-create.php
+++ b/qa-include/db/post-create.php
@@ -286,8 +286,14 @@
 	Update the cached count in the database of the number of questions (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_qcount', COUNT(*) FROM ^posts WHERE type='Q'");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_qcount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'Q' " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -296,8 +302,14 @@
 	Update the cached count in the database of the number of answers (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_acount', COUNT(*) FROM ^posts WHERE type='A'");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_acount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'A' " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -306,8 +318,14 @@
 	Update the cached count in the database of the number of comments (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_ccount', COUNT(*) FROM ^posts WHERE type='C'");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_ccount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'C' " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -316,8 +334,14 @@
 	Update the cached count in the database of the number of different tags used
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_tagcount', COUNT(*) FROM ^words WHERE tagcount>0");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_tagcount', COUNT(*) FROM ^words " .
+				"WHERE tagcount > 0 " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -326,8 +350,14 @@
 	Update the cached count in the database of the number of unanswered questions (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_unaqcount', COUNT(*) FROM ^posts WHERE type='Q' AND acount=0 AND closedbyid IS NULL");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_unaqcount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'Q' AND acount = 0 AND closedbyid IS NULL " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -336,8 +366,14 @@
 	Update the cached count in the database of the number of questions with no answer selected (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_unselqcount', COUNT(*) FROM ^posts WHERE type='Q' AND selchildid IS NULL AND closedbyid IS NULL");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_unselqcount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'Q' AND selchildid IS NULL AND closedbyid IS NULL " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -346,8 +382,14 @@
 	Update the cached count in the database of the number of questions with no upvoted answers (excluding hidden/queued)
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_unupaqcount', COUNT(*) FROM ^posts WHERE type='Q' AND amaxvote=0 AND closedbyid IS NULL");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_unupaqcount', COUNT(*) FROM ^posts " .
+				"WHERE type = 'Q' AND amaxvote = 0 AND closedbyid IS NULL " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 
@@ -356,8 +398,14 @@
 	Update the cached count in the database of the number of posts which are queued for moderation
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_queuedcount', COUNT(*) FROM ^posts WHERE type IN ('Q_QUEUED', 'A_QUEUED', 'C_QUEUED')");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_queuedcount', COUNT(*) FROM ^posts " .
+				"WHERE type IN ('Q_QUEUED', 'A_QUEUED', 'C_QUEUED') " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 /*

--- a/qa-include/db/post-update.php
+++ b/qa-include/db/post-update.php
@@ -351,8 +351,14 @@
 	Update the cached count of the number of flagged posts in the database
 */
 	{
-		if (qa_should_update_counts())
-			qa_db_query_sub("REPLACE ^options (title, content) SELECT 'cache_flaggedcount', COUNT(*) FROM ^posts WHERE flagcount>0 AND type IN ('Q', 'A', 'C')");
+		if (qa_should_update_counts()) {
+			qa_db_query_sub(
+				"INSERT INTO ^options (title, content) " .
+				"SELECT 'cache_flaggedcount', COUNT(*) FROM ^posts " .
+				"WHERE flagcount > 0 AND type IN ('Q', 'A', 'C') " .
+				"ON DUPLICATE KEY UPDATE content = VALUES(content)"
+			);
+		}
 	}
 
 /*


### PR DESCRIPTION
As discussed in http://www.question2answer.org/qa/45016/ `REPLACE` syntax is considerably slower than the `INSERT..ON DUPLICATE KEY UPDATE` so changing all of them seems to be the way to go.