### PR TITLE
[Refactor] Minor changes to the mouse-layer plugin

### DIFF
--- a/qa-include/util/string.php
+++ b/qa-include/util/string.php
@@ -495,14 +495,14 @@
 	 * @param string $ellipsis Text used to replace the removed words from the original text
 	 * @return string The string turned into a single line and cut to fit the given length
 	 */
-	function qa_shorten_string_line($string, $length)
+	function qa_shorten_string_line($string, $length, $ellipsis = ' ... ')
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		$string = strtr($string, "\r\n\t", '   ');
 
 		if (qa_strlen($string) > $length) {
-			$remaining = $length - 5;
+			$remaining = $length - qa_strlen($ellipsis);
 
 			$words = qa_string_to_words($string, false, true);
 			$countwords = count($words);
@@ -528,7 +528,7 @@
 				$remaining -= $wordLength;
 			}
 
-			$string = $prefix . ' ... ' . $suffix;
+			$string = $prefix . $ellipsis . $suffix;
 		}
 
 		return $string;

--- a/qa-include/util/string.php
+++ b/qa-include/util/string.php
@@ -485,11 +485,17 @@
 	}
 
 
+	/**
+	 * Converts a string to a single line and removes words from it until it fits in the given length. Words are removed
+	 * from a position around two thirds of the string and are replaced by the given ellipsis string
+	 *
+	 * @param string $string Text that will be turned into a single line and cut, if necessary
+	 * @param int $length Maximum allowed length of the returned string. This value can be overriden by the length of the
+	 * ellipsis if it is higher than the maximum allowed length
+	 * @param string $ellipsis Text used to replace the removed words from the original text
+	 * @return string The string turned into a single line and cut to fit the given length
+	 */
 	function qa_shorten_string_line($string, $length)
-/*
-	Return no more than $length characters from $string after converting it to a single line, by
-	removing words from the middle (and especially towards the end)
-*/
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 

--- a/qa-include/util/string.php
+++ b/qa-include/util/string.php
@@ -512,7 +512,9 @@
 				else
 					$word=array_shift($words);
 
-				if (qa_strlen($word)>$remaining)
+				$wordLength = qa_strlen($word);
+
+				if ($wordLength>$remaining)
 					break;
 
 				if ($tosuffix)
@@ -520,7 +522,7 @@
 				else
 					$prefix.=$word;
 
-				$remaining-=qa_strlen($word);
+				$remaining-=$wordLength;
 			}
 
 			$string=$prefix.' ... '.$suffix;

--- a/qa-include/util/string.php
+++ b/qa-include/util/string.php
@@ -493,39 +493,36 @@
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-		$string=strtr($string, "\r\n\t", '   ');
+		$string = strtr($string, "\r\n\t", '   ');
 
-		if (qa_strlen($string)>$length) {
-			$remaining=$length-5;
+		if (qa_strlen($string) > $length) {
+			$remaining = $length - 5;
 
-			$words=qa_string_to_words($string, false, true);
-			$countwords=count($words);
+			$words = qa_string_to_words($string, false, true);
+			$countwords = count($words);
 
-			$prefix='';
-			$suffix='';
+			$prefix = '';
+			$suffix = '';
 
-			for ($addword=0; $addword<$countwords; $addword++) {
-				$tosuffix=(($addword%3)==1); // order: prefix, suffix, prefix, prefix, suffix, prefix, ...
+			for ($addword = 0; $addword < $countwords; $addword++) {
+				$tosuffix = $addword % 3 == 1; // order: prefix, suffix, prefix, prefix, suffix, prefix, ...
 
-				if ($tosuffix)
-					$word=array_pop($words);
-				else
-					$word=array_shift($words);
+				$word = $tosuffix ? array_pop($words) : array_shift($words);
 
 				$wordLength = qa_strlen($word);
 
-				if ($wordLength>$remaining)
+				if ($wordLength > $remaining)
 					break;
 
 				if ($tosuffix)
-					$suffix=$word.$suffix;
+					$suffix = $word . $suffix;
 				else
-					$prefix.=$word;
+					$prefix .= $word;
 
-				$remaining-=$wordLength;
+				$remaining -= $wordLength;
 			}
 
-			$string=$prefix.' ... '.$suffix;
+			$string = $prefix . ' ... ' . $suffix;
 		}
 
 		return $string;

--- a/qa-plugin/mouseover-layer/qa-mouseover-layer.php
+++ b/qa-plugin/mouseover-layer/qa-mouseover-layer.php
@@ -31,16 +31,15 @@ class qa_html_theme_layer extends qa_html_theme_base
 			$postids = array();
 			foreach ($q_list['qs'] as $question) {
 				if (isset($question['raw']['postid']))
-						$postids[] = $question['raw']['postid'];
+					$postids[] = $question['raw']['postid'];
 			}
 
 			if (!empty($postids)) {
 
-				// Retrieve the content for these questions from the database and put into an array fetching
-				// the minimal amount of characters needed to determine the string should be shortened or not
+				// Retrieve the content for these questions from the database
 
 				$maxlength = qa_opt('mouseover_content_max_len');
-				$result = qa_db_query_sub('SELECT postid, LEFT(content, #) content, format FROM ^posts WHERE postid IN (#)', $maxlength + 1, $postids);
+				$result = qa_db_query_sub('SELECT postid, content, format FROM ^posts WHERE postid IN (#)', $postids);
 				$postinfo = qa_db_read_all_assoc($result, 'postid');
 
 				// Get the regular expression fragment to use for blocked words and the maximum length of content to show
@@ -53,14 +52,29 @@ class qa_html_theme_layer extends qa_html_theme_base
 					if (isset($postinfo[$question['raw']['postid']])) {
 						$thispost = $postinfo[$question['raw']['postid']];
 						$text = qa_viewer_text($thispost['content'], $thispost['format'], array('blockwordspreg' => $blockwordspreg));
+						$text = preg_replace('/\s+/', ' ', $text);  // Remove duplicated blanks, new line characters, tabs, etc
 						$text = qa_shorten_string_line($text, $maxlength);
 						$title = isset($question['title']) ? $question['title'] : '';
-						$q_list['qs'][$index]['title'] = sprintf('<span title="%s">%s</span>', qa_html($text), $title);
+						$q_list['qs'][$index]['title'] = $this->getHtmlTitle(qa_html($text), $title);
 					}
 				}
 			}
 		}
 
-		qa_html_theme_base::q_list($q_list); // call back through to the default function
+		parent::q_list($q_list); // call back through to the default function
+	}
+
+	/**
+	 * Returns the needed HTML to display the tip. Depending on the theme in use, this might need to be
+	 * tuned in order for the tip to be displayed properly
+	 *
+	 * @access private
+	 * @param string $mouseOverText Text of the tip
+	 * @param string $questionTitle Question title
+	 * @return string HTML needed to display the tip and the question title
+	 */
+	private function getHtmlTitle($mouseOverText, $questionTitle)
+	{
+		return sprintf('<span title="%s">%s</span>', $mouseOverText, $questionTitle);
 	}
 }


### PR DESCRIPTION
Minor refactor of `qa_shorten_string_line`
Minor changes to the mouse-layer plugin
  1. Fix #248 (text being cut twice)
  1. Split presentation logic
  1. Removed duplicated blanks, tabs, new lines, etc to compact the string