### PR TITLE
[Refactor] Let user know why they can't send a private message to another user

### DIFF
--- a/qa-include/lang/qa-lang-profile.php
+++ b/qa-include/lang/qa-lang-profile.php
@@ -77,6 +77,7 @@
 		'set_bonus_button' => 'Update bonus',
 		'title' => 'Title:',
 		'user_x' => 'User ^',
+		'user_x_disabled_private_messages' => 'User ^ has disabled private messages.',
 		'voted_on' => 'Voted on:',
 		'wall_for_x' => 'Wall for ^',
 		'wall_view_more' => 'View more wall posts...',

--- a/qa-include/pages/message.php
+++ b/qa-include/pages/message.php
@@ -68,9 +68,18 @@
 
 //	Check the user exists and work out what can and can't be set (if not using single sign-on)
 
-	if ( !qa_opt('allow_private_messages') || !is_array($toaccount) || ($toaccount['flags'] & QA_USER_FLAGS_NO_MESSAGES) )
+	if (!qa_opt('allow_private_messages') || !is_array($toaccount))
 		return include QA_INCLUDE_DIR.'qa-page-not-found.php';
 
+//  Check the target user has enabled private messages and inform the current user in case they haven't
+
+	if ($toaccount['flags'] & QA_USER_FLAGS_NO_MESSAGES) {
+		$qa_content['error'] = qa_lang_html_sub(
+			'profile/user_x_disabled_private_messages',
+			sprintf('<a href="%s">%s</a>', qa_path_html('user/' . $handle), qa_html($handle))
+		);
+		return $qa_content;
+	}
 
 //	Check that we have permission and haven't reached the limit, but don't quit just yet
 


### PR DESCRIPTION
It seems accessing a private message URL (http://yoursite.com/message/pupi1985) of a user who has not enabled private messages results in a "Page not found" error message. IMO, this could be OK.

However, considering the fact that emails sent from private messages have a "Reply" button it is possible to receive an email with a link to this page. If the original user disabled private messages from their profile after the email was sent and the recipient of the email tries to reply from the link in the email, they will get the "Page not found" error message. This might be confusing and might lead to think the original user has been deleted.

Reference: http://www.question2answer.org/qa/46582