### PR TITLE
[Bugfix] Fixed infinite loop and cleaned the core from some JS

### DIFF
--- a/qa-content/qa-page.js
+++ b/qa-content/qa-page.js
@@ -175,3 +175,29 @@ function qa_ajax_error()
 {
 	alert('Unexpected response from server - please try again or switch off Javascript.');
 }
+
+function qa_display_run(source, target, first) {
+	var sourceEnabled = source && (source.checked || (source.options && source.options[source.selectedIndex].value));
+	if (first || target.nodeName === 'SPAN')
+		target.style.display = sourceEnabled ? '' : 'none';
+	else {
+		if (sourceEnabled)
+			$(target).fadeIn();
+		else
+			$(target).fadeOut();
+	}
+}
+
+function qa_display_rules(first, rules) {
+	for (var i = 0; i < rules.length; i++) {
+		var rule = rules[i];
+		var source = document.getElementById(rule.source);
+		var target = document.getElementById(rule.target);
+		if (source && target) {
+			qa_display_run(source, target, first);
+			$(source).click({source: source, target: target}, function (e) {
+				qa_display_run(e.data.source, e.data.target, false);
+			});
+		}
+	}
+}

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1439,42 +1439,18 @@
 	also combine multiple DOM IDs using JavaScript(=PHP) operators. This is twisted but rather convenient.
 */
 	{
-		$function='qa_display_rule_'.count(@$qa_content['script_lines']);
+		if (empty($effects))
+			return;
 
-		$keysourceids=array();
-
-		foreach ($effects as $target => $sources)
-			if (preg_match_all('/[A-Za-z_][A-Za-z0-9_]*/', $sources, $matches)) // element names must be legal JS variable names
-				foreach ($matches[0] as $element)
-					$keysourceids[$element]=true;
-
-		$funcscript=array("function ".$function."(first) {"); // build the Javascripts
-		$loadscript=array();
-
-		foreach ($keysourceids as $key => $dummy) {
-			$funcscript[]="\tvar e=document.getElementById(".qa_js($key).");";
-			$funcscript[]="\tvar ".$key."=e && (e.checked || (e.options && e.options[e.selectedIndex].value));";
-			$loadscript[]="var e=document.getElementById(".qa_js($key).");";
-			$loadscript[]="if (e) {";
-			$loadscript[]="\t".$key."_oldonclick=e.onclick;";
-			$loadscript[]="\te.onclick=function() {";
-			$loadscript[]="\t\t".$function."(false);";
-			$loadscript[]="\t\tif (typeof ".$key."_oldonclick=='function')";
-			$loadscript[]="\t\t\t".$key."_oldonclick();";
-			$loadscript[]="\t};";
-			$loadscript[]="}";
+		$rules = array();
+		foreach ($effects as $target => $source) {
+			$rules[] = array(
+				'source' => $source,
+				'target' => $target,
+			);
 		}
 
-		foreach ($effects as $target => $sources) {
-			$funcscript[]="\tvar e=document.getElementById(".qa_js($target).");";
-			$funcscript[]="\tif (e) { var d=(".$sources."); if (first || (e.nodeName=='SPAN')) { e.style.display=d ? '' : 'none'; } else { if (d) { $(e).fadeIn(); } else { $(e).fadeOut(); } } }";
-		}
-
-		$funcscript[]="}";
-		$loadscript[]=$function."(true);";
-
-		$qa_content['script_lines'][]=$funcscript;
-		$qa_content['script_onloads'][]=$loadscript;
+		$qa_content['script_onloads'][] = sprintf("qa_display_rules(true, %s);", json_encode($rules));
 	}
 
 

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1431,23 +1431,41 @@
 		return 10-2*$match;
 	}
 
-
-	function qa_set_display_rules(&$qa_content, $effects)
-/*
-	For each [target] => [source] in $effects, set up $qa_content so that the visibility of the DOM element ID
-	target is equal to the checked state or boolean-casted value of the DOM element ID source. Each source can
-	also combine multiple DOM IDs using JavaScript(=PHP) operators. This is twisted but rather convenient.
-*/
+	/**
+	 * For each rule in $rules, set up $qa_content so that the visibility of the DOM element ID
+	 * target is equal to the checked state or boolean-casted value of the DOM element ID source. Each source can
+	 * also combine multiple DOM IDs using JavaScript(=PHP) operators. This is twisted but rather convenient.
+	 *
+	 * @param array $qa_content The core's content array
+	 * @param array $rules This parameter must have the following structure:
+	 *
+	 * <code>
+	 * array(
+	 *     array(
+	 *         'source' => 'source_dom_id1',
+	 *         'target' => 'target_dom_id2',
+	 *     ),
+	 *     array(
+	 *         'source' => 'source_dom_id3',
+	 *         'target' => 'target_dom_id4',
+	 *     ),
+	 * );
+	 * </code>
+	 */
+	function qa_set_display_rules(&$qa_content, $rules)
 	{
-		if (empty($effects))
+		if (empty($rules))
 			return;
 
-		$rules = array();
-		foreach ($effects as $target => $source) {
-			$rules[] = array(
-				'source' => $source,
-				'target' => $target,
-			);
+		if (!isset($rules[0])) { // Backwards compatibility fix
+			$newRules = array();
+			foreach ($rules as $target => $source) {
+				$newRules[] = array(
+					'source' => $source,
+					'target' => $target,
+				);
+			}
+			$rules = $newRules;
 		}
 
 		$qa_content['script_onloads'][] = sprintf("qa_display_rules(true, %s);", json_encode($rules));


### PR DESCRIPTION
This works:

```php
qa_set_display_rules($qa_content, array(
	'target1' => 'source1',
	'target2' => 'source1',
));
```

While this doesn't as it seems to generate an infinite loop:

```php
qa_set_display_rules($qa_content, array(
	'target1' => 'source1',
));

qa_set_display_rules($qa_content, array(
	'target2' => 'source1',
));
```

The first commit fixes the issue and removes a lot of JS from the core, which can become very long sometimes!

The second commit suggest a different way of handling the source/target approach:

```php
qa_set_display_rules($qa_content, array(
	array(
		'source' => 'source1',
		'target' => 'target1',
	),
	array(
		'source' => 'source1',
		'target' => 'target2',
	),
));
```

The only pending thing would be to deprecate the old format.