### PR TITLE
Q2A user levels with Wordpress integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore config file in development
 qa-config.php
+/.idea


### PR DESCRIPTION
Hi!
I use your great Q2A product and I really appreciate your work! 
So thank's a lot for it!

Using it with WP users external DB (great integration!) I found a problem: when users log in Q2A thought their WP account Q2A relative users level won't be stored on Q2A DB, instead they are loaded dynamically during login.

This is a problem for me because I had to implement some theme / plugin functionalities based on Q2A user level (moderator) and I had to catch this trought a DB query for performance reasons.
So I decided to modify externalisers-wp.php in my Q2A version to write on Q2A DB users levels logged thought WP login.

I hope this help and you like to accept my pull request.

Best regards. 
