### PR TITLE
[BugFix] - Correct url after posting a comment to the question 

### DIFF
--- a/qa-include/pages/question-post.php
+++ b/qa-include/pages/question-post.php
@@ -872,7 +872,7 @@
 					$commentid=qa_page_q_add_c_submit($question, $parent, $commentsfollows, $usecaptcha, $cnewin[$parentid], $cnewerrors[$parentid]);
 
 					if (isset($commentid))
-						qa_page_q_refresh($pagestart, null, $parent['basetype'], $parentid);
+						qa_page_q_refresh($pagestart, null, 'C', $commentid);
 
 					else {
 						$formtype='c_add';


### PR DESCRIPTION
After posting a comment to a question the comment anchor is wrong . This
commit fixes this issue with the correct anchor
fixed #266