### PR TITLE
[BugFix]-Restrict the user to post duplicate questions

### DIFF
--- a/qa-include/pages/ask.php
+++ b/qa-include/pages/ask.php
@@ -136,6 +136,18 @@
 			}
 
 			if (empty($errors)) {
+				//check if the question is already posted
+				$testwords=implode(' ', qa_string_to_words($in['content']));
+				$recent_questions = qa_db_select_with_pending(qa_db_qs_selectspec(null, 'created', 0, null, null, false, true, 5));
+				foreach ($recent_questions as $recent_question)
+					if (!$recent_question['hidden'])
+						if (implode(' ', qa_string_to_words($recent_question['content'])) == $testwords){
+							$errors['page']=qa_lang_html('question/duplicate_content');
+							break;
+						}
+			}
+
+			if (empty($errors)) {
 				$cookieid=isset($userid) ? qa_cookie_get() : qa_cookie_get_create(); // create a new cookie if necessary
 
 				$questionid=qa_question_create($followanswer, $userid, qa_get_logged_in_handle(), $cookieid,


### PR DESCRIPTION
do not allow user to post the duplicate question once more time . It
checks the last 5 questions and compares with the current one . If any
of them appears to be same the user will be warned and the question will
not be posted
Fixes - #309