### PR TITLE
[dev] use password_hash and password_verify

### DIFF
--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -1429,13 +1429,13 @@
 					$keyrecalc['dorecalcpoints'] = true;
 					break;
 
-			//	Up to here: Verison 1.7
+			//	Up to here: Version 1.7
 
 				case 59:
 					// Upgrade from alpha version removed
 					break;
 
-			//	Up to here: Verison 1.7.1
+			//	Up to here: Version 1.7.1
 				case 60:
 						qa_db_upgrade_query('ALTER TABLE ^users ADD COLUMN passhash '.$definitions['users']['passhash'].' AFTER passcheck');
 						qa_db_upgrade_query($locktablesquery);

--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -25,7 +25,7 @@
 		exit;
 	}
 
-	define('QA_DB_VERSION_CURRENT', 59);
+	define('QA_DB_VERSION_CURRENT', 60);
 
 
 	function qa_db_user_column_type_verify()
@@ -107,7 +107,8 @@
 				'avatarwidth' => 'SMALLINT UNSIGNED', // pixel width of stored avatar
 				'avatarheight' => 'SMALLINT UNSIGNED', // pixel height of stored avatar
 				'passsalt' => 'BINARY(16)', // salt used to calculate passcheck - null if no password set for direct login
-				'passcheck' => 'BINARY(20)', // checksum from password and passsalt - null if no passowrd set for direct login
+				'passcheck' => 'BINARY(20)', // checksum from password and passsalt - null if no password set for direct login
+				'passhash' => 'CHAR(60) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL', // password_hash
 				'level' => 'TINYINT UNSIGNED NOT NULL', // basic, editor, admin, etc...
 				'loggedin' => 'DATETIME NOT NULL', // time of last login
 				'loginip' => 'INT UNSIGNED NOT NULL', // INET_ATON of IP address of last login
@@ -1435,6 +1436,10 @@
 					break;
 
 			//	Up to here: Verison 1.7.1
+				case 60:
+						qa_db_upgrade_query('ALTER TABLE ^users ADD COLUMN passhash '.$definitions['users']['passhash'].' AFTER passcheck');
+						qa_db_upgrade_query($locktablesquery);
+						break;
 
 			}
 

--- a/qa-include/db/selects.php
+++ b/qa-include/db/selects.php
@@ -1181,7 +1181,7 @@
 	{
 		return array(
 			'columns' => array(
-				'^users.userid', 'passsalt', 'passcheck' => 'HEX(passcheck)', 'email', 'level', 'emailcode', 'handle',
+				'^users.userid', 'passsalt', 'passcheck' => 'HEX(passcheck)', 'passhash', 'email', 'level', 'emailcode', 'handle',
 				'created' => 'UNIX_TIMESTAMP(created)', 'sessioncode', 'sessionsource', 'flags', 'loggedin' => 'UNIX_TIMESTAMP(loggedin)',
 				'loginip' => 'INET_NTOA(loginip)', 'written' => 'UNIX_TIMESTAMP(written)', 'writeip' => 'INET_NTOA(writeip)',
 				'avatarblobid' => 'BINARY avatarblobid', // cast to BINARY due to MySQL bug which renders it signed in a union

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -47,9 +47,9 @@
 		$salt=isset($password) ? qa_random_alphanum(16) : null;
 
 		qa_db_query_sub(
-			'INSERT INTO ^users (created, createip, email, passsalt, passhash, level, handle, loggedin, loginip) '.
+			'INSERT INTO ^users (created, createip, email, passhash, level, handle, loggedin, loginip) '.
 			'VALUES (NOW(), COALESCE(INET_ATON($), 0), $, $, $, #, $, NOW(), COALESCE(INET_ATON($), 0))',
-			$ip, $email, $salt, isset($password) ? password_hash($password, PASSWORD_BCRYPT) : null, (int)$level, $handle, $ip
+			$ip, $email, isset($password) ? password_hash($password, PASSWORD_BCRYPT) : null, (int)$level, $handle, $ip
 		);
 
 		return qa_db_last_insert_id();

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -36,6 +36,7 @@
 		return sha1(substr($salt, 0, 8).$password.substr($salt, 8));
 	}
 
+
 	function qa_db_user_create($email, $password, $handle, $level, $ip)
 /*
 	Create a new user in the database with $email, $password, $handle, privilege $level, and $ip address

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -19,7 +19,11 @@
 
 	More about this license: http://www.question2answer.org/license.php
 */
-
+	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+		header('Location: ../');
+		exit;
+	}
+	
 	function qa_db_calc_passcheck($password, $salt)
 /*
 	Return the expected value for the passcheck column given the $password and password $salt
@@ -28,11 +32,6 @@
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		return sha1(substr($salt, 0, 8).$password.substr($salt, 8));
-	}
-
-	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
-		header('Location: ../');
-		exit;
 	}
 
 	function qa_db_user_create($email, $password, $handle, $level, $ip)

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -24,7 +24,8 @@
 		header('Location: ../');
 		exit;
 	}
-	
+
+
 	function qa_db_calc_passcheck($password, $salt)
 /*
 	Return the expected value for the passcheck column given the $password and password $salt

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -19,7 +19,7 @@
 
 	More about this license: http://www.question2answer.org/license.php
 */
-	
+
 	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
 		header('Location: ../');
 		exit;

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -19,6 +19,7 @@
 
 	More about this license: http://www.question2answer.org/license.php
 */
+	
 	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
 		header('Location: ../');
 		exit;

--- a/qa-include/pages/account.php
+++ b/qa-include/pages/account.php
@@ -183,7 +183,7 @@
 
 				if (
 				($haspasswordold && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck']))) ||
-				(!$haspasswordold && $haspassword && !password_verify($inoldpassword,$useraccount['passhash']))
+				($haspassword && !password_verify($inoldpassword,$useraccount['passhash']))
 				)
 					$errors['oldpassword'] = qa_lang('users/password_wrong');
 

--- a/qa-include/pages/account.php
+++ b/qa-include/pages/account.php
@@ -55,7 +55,8 @@
 	$changehandle=qa_opt('allow_change_usernames') || ((!$userpoints['qposts']) && (!$userpoints['aposts']) && (!$userpoints['cposts']));
 	$doconfirms=qa_opt('confirm_user_emails') && ($useraccount['level']<QA_USER_LEVEL_EXPERT);
 	$isconfirmed=($useraccount['flags'] & QA_USER_FLAGS_EMAIL_CONFIRMED) ? true : false;
-	$haspassword=isset($useraccount['passsalt']) && isset($useraccount['passcheck']);
+	$haspasswordold=isset($useraccount['passsalt']) && isset($useraccount['passcheck']);
+	$haspassword=isset($useraccount['passhash']);
 	$isblocked = qa_user_permit_error() !== false;
 
 
@@ -179,8 +180,10 @@
 
 			else {
 				$errors = array();
-
-				if ($haspassword && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck'])))
+				if (
+				($haspasswordold && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck']))) ||
+				(!$haspasswordold && $haspassword && !password_verify($inoldpassword,$useraccount['passhash']))
+				)
 					$errors['oldpassword'] = qa_lang('users/password_wrong');
 
 				$useraccount['password'] = $inoldpassword;

--- a/qa-include/pages/account.php
+++ b/qa-include/pages/account.php
@@ -180,6 +180,7 @@
 
 			else {
 				$errors = array();
+
 				if (
 				($haspasswordold && (strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck']))) ||
 				(!$haspasswordold && $haspassword && !password_verify($inoldpassword,$useraccount['passhash']))

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -76,6 +76,7 @@
 					($haspassword && password_verify($inpassword,$userinfo['passhash']))
 					){ // login and redirect
 						require_once QA_INCLUDE_DIR.'app/users.php';
+						
 						if($haspasswordold) qa_db_user_set_password($inuserid, $inpassword);
 						qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
 

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -67,10 +67,16 @@
 				if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
 					$inuserid=$matchusers[0];
 					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
-
-					if (strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) { // login and redirect
+					
+					$haspassword=isset($userinfo['passhash']);
+					$haspasswordold=isset($userinfo['passsalt']) && isset($userinfo['passcheck']);
+					
+					if (
+					($haspasswordold && strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) ||
+					($haspassword && password_verify($inpassword,$userinfo['passhash']))
+					){ // login and redirect
 						require_once QA_INCLUDE_DIR.'app/users.php';
-
+						if($haspasswordold) qa_db_user_set_password($inuserid, $inpassword);
 						qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
 
 						$topath=qa_get('to');

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -67,10 +67,10 @@
 				if (count($matchusers)==1) { // if matches more than one (should be impossible), don't log in
 					$inuserid=$matchusers[0];
 					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
-					
+
 					$haspassword=isset($userinfo['passhash']);
 					$haspasswordold=isset($userinfo['passsalt']) && isset($userinfo['passcheck']);
-					
+
 					if (
 					($haspasswordold && strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck'])) ||
 					($haspassword && password_verify($inpassword,$userinfo['passhash']))

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -76,7 +76,7 @@
 					($haspassword && password_verify($inpassword,$userinfo['passhash']))
 					){ // login and redirect
 						require_once QA_INCLUDE_DIR.'app/users.php';
-						
+
 						if($haspasswordold) qa_db_user_set_password($inuserid, $inpassword);
 						qa_set_logged_in_user($inuserid, $userinfo['handle'], !empty($inremember));
 


### PR DESCRIPTION
Please test it.

This pull request converts user hashes after a successful login, and uses bcrypt for all new passwords by default.

You need to add password_compat functions to question2answer to make it compatible with PHP 5.3+ (I work with PHP 5.6 and 7.0 on my local machine).

Worked here without any issues.

This pull request solves #340

Keep in mind that we do not need any salt as password_hash creates a safe hash by default.