### PR TITLE
Replaced registration URL for WordPress integration

### DIFF
--- a/qa-include/util/external-users-wp.php
+++ b/qa-include/util/external-users-wp.php
@@ -36,7 +36,7 @@
 	{
 		return array(
 			'login' => wp_login_url(qa_opt('site_url').$redirect_back_to_url),
-			'register' => site_url('wp-login.php?action=register'),
+			'register' => function_exists('wp_registration_url') ? wp_registration_url() : site_url('wp-login.php?action=register'),
 			'logout' => strtr(wp_logout_url(), array('&amp;' => '&')),
 		);
 	}


### PR DESCRIPTION
Q2A doesn't use `wp_registration_url` WP function for fetching registration URL so it bypasses `register_url` filter. This filter can be used for adding custom registration pages.

I added WordPress function `wp_registration_url` for fetching registration URL while still keeping compatibility with older WordPress (bellow 3.6) that do not have this function.