### PR TITLE
[security] use hash_equals to compare hashes

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -367,7 +367,7 @@
 				$sessionuserid=@$_SESSION['qa_session_userid_'.$suffix];
 
 				if (isset($sessionuserid)) // check verify code matches
-					if (@$_SESSION['qa_session_verify_'.$suffix] != qa_session_verify_code($sessionuserid))
+					if (!hash_equals(qa_session_verify_code($sessionuserid), @$_SESSION['qa_session_verify_'.$suffix]))
 						qa_clear_session_user();
 
 				if (!empty($_COOKIE['qa_session'])) {
@@ -1178,7 +1178,7 @@ in a category for which they have elevated privileges).
 				}
 
 				if (empty($silentproblems) && empty($reportproblems))
-					if (strtolower(qa_calc_form_security_hash($action, $timestamp))!=strtolower($hash))
+					if (!hash_equals(strtolower(qa_calc_form_security_hash($action, $timestamp)), strtolower($hash)))
 						$reportproblems[]='code mismatch';
 
 			} else

--- a/qa-include/pages/account.php
+++ b/qa-include/pages/account.php
@@ -210,7 +210,7 @@
 
 			else {
 				$errors = array();
-				$legacyPassError = strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])) != strtolower($useraccount['passcheck']);
+				$legacyPassError = !hash_equals(strtolower($useraccount['passcheck']), strtolower(qa_db_calc_passcheck($inoldpassword, $useraccount['passsalt'])));
 
 				if (QA_PASSWORD_HASH) {
 					$passError = !password_verify($inoldpassword,$useraccount['passhash']);

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -68,7 +68,7 @@
 					$inuserid=$matchusers[0];
 					$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
 
-					$legacyPassOk = strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])) == strtolower($userinfo['passcheck']);
+					$legacyPassOk = hash_equals(strtolower($userinfo['passcheck']), strtolower(qa_db_calc_passcheck($inpassword, $userinfo['passsalt'])));
 
 					if (QA_PASSWORD_HASH) {
 						$haspassword = isset($userinfo['passhash']);

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -203,6 +203,20 @@
 			require_once QA_INCLUDE_DIR.'vendor/password_compat.php';
 		}
 
+		// http://php.net/manual/en/function.hash-equals.php#115635
+		if(!function_exists('hash_equals')) {
+			function hash_equals($str1, $str2) {
+				if(strlen($str1) != strlen($str2)) {
+					return false;
+				} else {
+					$res = $str1 ^ $str2;
+					$ret = 0;
+					for($i = strlen($res) - 1; $i >= 0; $i--) $ret |= ord($res[$i]);
+					return !$ret;
+				}
+			}
+		}
+
 		// http://stackoverflow.com/a/18277167
 		function ipv6_numeric($ip) {
 			$binNum = '';


### PR DESCRIPTION
hash_equals provides a timing attack safe string comparison for hashes