### PR TITLE
Out-of-the-box Joomla! integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Q2A is highly customisable with many awesome features:
 - Private messages and public wall posts.
 - Log in via Facebook or others (using plugins).
 - Out-of-the-box WordPress 3+ integration.
+- Out-of-the-box Joomla! 3.0+ integration (in conjunction with a Joomla! extension).
 - Custom single sign-on support for other sites.
 - PHP/MySQL scalable to millions of users and posts.
 - Safe from XSS, CSRF and SQL injection attacks.

--- a/qa-config-example.php
+++ b/qa-config-example.php
@@ -128,6 +128,17 @@
 */
 
 /*
+	Out-of-the-box Joomla! 3.x integration - to integrate with your Joomla! site, define
+	QA_JOOMLA_INTEGRATE_PATH. as the full path to the Joomla! directory. If your Q2A
+    site is a subdirectory of your main Joomla site (recommended), you can specify
+    dirname(__DIR__) rather than the full path.
+	With this set, you do not need to set the QA_MYSQL_* constants above since these
+	will be taken from Joomla automatically. See online documentation for more details.
+
+	define('QA_JOOMLA_INTEGRATE_PATH', dirname(__DIR__));
+*/
+
+/*
 	Some settings to help optimize your Question2Answer site's performance.
 
 	If QA_HTML_COMPRESSION is true, HTML web pages will be output using Gzip compression, if

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -56,11 +56,16 @@
 
 	//	If we're using single sign-on integration (WordPress or otherwise), load PHP file for that
 
-		if (defined('QA_FINAL_WORDPRESS_INTEGRATE_PATH'))
+		if (defined('QA_FINAL_WORDPRESS_INTEGRATE_PATH')) {
 			require_once QA_INCLUDE_DIR.'util/external-users-wp.php';
-		else
+		}
+		elseif (defined('QA_FINAL_JOOMLA_INTEGRATE_PATH')) {
+            //grab the integration file that is included as part of the Joomla plugin (we already confirmed that it exists).
+			require_once QA_JOOMLA_PLUGIN_SSO_FILE;
+		}
+		else {
 			require_once QA_EXTERNAL_DIR.'qa-external-users.php';
-
+        }
 
 	//	Access functions for user information
 

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -60,8 +60,7 @@
 			require_once QA_INCLUDE_DIR.'util/external-users-wp.php';
 		}
 		elseif (defined('QA_FINAL_JOOMLA_INTEGRATE_PATH')) {
-            //grab the integration file that is included as part of the Joomla plugin (we already confirmed that it exists).
-			require_once QA_JOOMLA_PLUGIN_SSO_FILE;
+			require_once QA_INCLUDE_DIR.'util/external-users-joomla.php';
 		}
 		else {
 			require_once QA_EXTERNAL_DIR.'qa-external-users.php';

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -186,12 +186,9 @@
 		elseif (defined('QA_JOOMLA_INTEGRATE_PATH') && strlen(QA_JOOMLA_INTEGRATE_PATH)) {
 			define('QA_FINAL_JOOMLA_INTEGRATE_PATH', QA_JOOMLA_INTEGRATE_PATH.((substr(QA_JOOMLA_INTEGRATE_PATH, -1)=='/') ? '' : '/'));
 			define('QA_JOOMLA_LOAD_FILE', QA_FINAL_JOOMLA_INTEGRATE_PATH.'configuration.php');
-			define('QA_JOOMLA_PLUGIN_SSO_FILE', QA_FINAL_JOOMLA_INTEGRATE_PATH.'plugins/q2a/qaintegration/qa-external/qa-external-users.php');
 
 			if (!is_readable(QA_JOOMLA_LOAD_FILE))
 				qa_fatal_error('Could not find configuration.php file for Joomla integration - please check QA_JOOMLA_INTEGRATE_PATH in qa-config.php');
-			if (!is_readable(QA_JOOMLA_PLUGIN_SSO_FILE))
-				qa_fatal_error('Could not find Joomla Q2AIntegration plugin - please check that you have installed the plugin into your Joomla system.');
 		}
 
 		// Polyfills

--- a/qa-include/qa-install.php
+++ b/qa-include/qa-install.php
@@ -150,6 +150,15 @@ else {
 				$success .= 'Your Question2Answer database has been created and integrated with your WordPress site.';
 
 			}
+			elseif (defined('QA_FINAL_JOOMLA_INTEGRATE_PATH')) {
+				require_once QA_INCLUDE_DIR.'db/admin.php';
+				require_once QA_INCLUDE_DIR.'app/format.php';
+				$jconfig = new JConfig();
+
+				// create link back to Joomla! home page (Joomla doesn't have a 'home' config setting we can use like WP does, so we'll just assume that the Joomla home is the parent of the Q2A site. If it isn't, the user can fix the link for themselves later)
+				qa_db_page_move(qa_db_page_create($jconfig->sitename, QA_PAGE_FLAGS_EXTERNAL, '../', null, null, null), 'O', 1);
+				$success .= 'Your Question2Answer database has been created and integrated with your Joomla! site.';
+			}
 			else {
 				$success .= 'Your Question2Answer database has been created for external user identity management. Please read the online documentation to complete integration.';
 			}
@@ -208,6 +217,10 @@ if (qa_db_connection(false) !== null && !@$pass_failure_from_install) {
 			if (QA_FINAL_EXTERNAL_USERS) {
 				if (defined('QA_FINAL_WORDPRESS_INTEGRATE_PATH')) {
 					$errorhtml .= "\n\nWhen you click below, your Question2Answer site will be set up to integrate with the users of your WordPress site <a href=\"".qa_html(get_option('home'))."\" target=\"_blank\">".qa_html(get_option('blogname'))."</a>. Please consult the online documentation for more information.";
+				}
+				elseif (defined('QA_FINAL_JOOMLA_INTEGRATE_PATH')) {
+                    $jconfig = new JConfig();
+					$errorhtml .= "\n\nWhen you click below, your Question2Answer site will be set up to integrate with the users of your Joomla! site <a href=\"../\" target=\"_blank\">".$jconfig->sitename."</a>. To complete the process, you will need to create a ensure that the QAIntegration plugin in Joomla is configured and enabled, and you will need to create a menu entry or a link in your Joomla site pointing to the URL for your Q2A installation. Please consult the online documentation for more information.";
 				}
 				else {
 					$errorhtml .= "\n\nWhen you click below, your Question2Answer site will be set up to integrate with your existing user database and management. Users will be referenced with database column type ".qa_html(qa_get_mysql_user_column_type()).". Please consult the online documentation for more information.";

--- a/qa-include/util/external-users-joomla.php
+++ b/qa-include/util/external-users-joomla.php
@@ -1,0 +1,166 @@
+<?php
+/*
+	Question2Answer by Gideon Greenspan and contributors
+	http://www.question2answer.org/
+
+	File: qa-include/qa-external-users-joomla.php
+	Description: External user functions for basic Joomla integration
+
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	More about this license: http://www.question2answer.org/license.php
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+    header('Location: ../');
+    exit;
+}
+
+require('qa-joomla-helper.php');
+
+function qa_get_mysql_user_column_type()
+{
+    return "INT";
+}
+
+function qa_get_login_links($relative_url_prefix, $redirect_back_to_url)
+{
+    $jhelper = new qa_joomla_helper();
+    $config_urls = $jhelper->trigger_get_urls_event();
+    return array(
+        'login'     => $config_urls['login'].'&return='.urlencode(base64_encode($redirect_back_to_url)),
+        'register'  => $config_urls['reg'],
+        'logout'    => $config_urls['logout']
+    );
+}
+
+function qa_get_logged_in_user()
+{
+    $jhelper = new qa_joomla_helper();
+    $user = $jhelper->get_user();
+    $config_urls = $jhelper->trigger_get_urls_event();
+
+    if($user) {
+      if($user->guest || $user->block) {
+        header('location:'.$config_urls['denied']);
+        die;
+      }
+
+      $access = $jhelper->trigger_access_event($user);
+
+      if(!$access['view']) {     //must be in a group that has the view level set at least.
+        header('location:'.$config_urls['denied']);
+        die;
+      }
+      $level = QA_USER_LEVEL_BASIC;
+      if($access['post'])  {$level = QA_USER_LEVEL_APPROVED;}
+      if($access['edit'])  {$level = QA_USER_LEVEL_EDITOR;}
+      if($access['mod'])   {$level = QA_USER_LEVEL_MODERATOR;}
+      if($access['admin']) {$level = QA_USER_LEVEL_ADMIN;}
+      if($access['super'] || $user->get('isRoot')) {$level = QA_USER_LEVEL_SUPER;}
+
+      $teamGroup = $jhelper->trigger_team_group_event($user);
+
+      return [
+        'userid' => $user->id,
+        'publicusername' => $user->name.($teamGroup ? " ({$teamGroup})" : ''),
+        'email' => $user->email,
+        'level' => $level,
+      ];
+    }
+
+    return null;
+}
+
+function qa_get_user_email($userid)
+{
+    $jhelper = new qa_joomla_helper();
+    $user = $jhelper->get_user($userid);
+
+    if($user) {
+      return $user->email;
+    }
+
+    return null;
+}
+
+function qa_get_userids_from_public($publicusernames)
+{
+    $output = [];
+    if(count($publicusernames)) {
+      $jhelper = new qa_joomla_helper();
+      foreach($publicusernames as $username) {
+        $output[$username] = $jhelper->get_userid($username);
+      }
+    }
+    return $output;
+}
+
+function qa_get_public_from_userids($userids)
+{
+    $output = [];
+    if(count($userids)) {
+      $jhelper = new qa_joomla_helper();
+      foreach($userids as $userID) {
+        $user = $jhelper->get_user($userID);
+        $teamGroup = $jhelper->trigger_team_group_event($user);
+        $output[$userID] = $user->name.($teamGroup ? " ({$teamGroup})" : '');
+      }
+    }
+    return $output;
+}
+
+function qa_get_logged_in_user_html($logged_in_user, $relative_url_prefix)
+{
+    $publicusername=$logged_in_user['publicusername'];
+    return '<a href="'.qa_path_html('user/'.$publicusername).'" class="qa-user-link">'.htmlspecialchars($publicusername).'</a>';
+}
+
+function qa_get_users_html($userids, $should_include_link, $relative_url_prefix)
+{
+    $useridtopublic = qa_get_public_from_userids($userids);
+    $usershtml = array();
+
+    foreach ($userids as $userid) {
+        $publicusername = $useridtopublic[$userid];
+        $usershtml[$userid] = htmlspecialchars($publicusername);
+
+        if ($should_include_link) {
+            $usershtml[$userid]='<a href="'.qa_path_html('user/'.$publicusername).'" class="qa-user-link">'.$usershtml[$userid].'</a>';
+        }
+    }
+
+    return $usershtml;
+}
+
+function qa_avatar_html_from_userid($userid, $size, $padding)
+{
+    $jhelper = new qa_joomla_helper();
+    $avatarURL = $jhelper->trigger_get_avatar_event($userid, $size);
+
+    $avatarHTML = $avatarURL ? "<img src='{$avatarURL}' class='qa-avatar-image' alt=''/>" : '';
+    if ($padding) {
+        //If $padding is true, the HTML you return should render to a square of $size x $size pixels, even if the avatar is not square.
+        $avatarHTML = "<span style='display:inline-block; width:{$size}px; height:{$size}px; overflow:hidden;'>{$avatarHTML}</span>";
+    }
+    return $avatarHTML;
+}
+
+function qa_user_report_action($userid, $action)
+{
+    $jhelper = new qa_joomla_helper();
+    $jhelper->trigger_log_event($userid, $action);
+}
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-include/util/qa-joomla-helper.php
+++ b/qa-include/util/qa-joomla-helper.php
@@ -125,9 +125,9 @@ class qa_joomla_default_integration
     public static function onGetURLs()
     {
         return array(
-            'login'  => '/login.html',
-            'logout' => '/logout.html',
-            'reg'    => '/register.html',
+            'login'  => JRoute::_('index.php?option=com_users&view=login'),
+            'logout' => JRoute::_('index.php?option=com_users&view=login&layout=logout'),
+            'reg'    => JRoute::_('index.php?option=com_users&view=registration'),
             'denied' => '/',
         );
     }

--- a/qa-include/util/qa-joomla-helper.php
+++ b/qa-include/util/qa-joomla-helper.php
@@ -1,0 +1,187 @@
+<?php
+/*
+	Question2Answer by Gideon Greenspan and contributors
+	http://www.question2answer.org/
+
+	File: qa-include/qa-external-users-joomla.php
+	Description: External user functions for basic Joomla integration
+
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	More about this license: http://www.question2answer.org/license.php
+*/
+
+/**
+ * Link to Joomla app.
+ */
+class qa_joomla_helper {
+
+    private $app;
+
+    public function __construct()
+    {
+        $this->find_joomla_path();
+        $this->load_joomla_app();
+    }
+
+    /* 
+     * If your Q2A installation is in a subfolder of your Joomla, then this file should be in joomla-root/qa-root/qa-include/util/
+     * We can use this info to track back up the tree to find the Joomla root.
+     * If your Q2A installation is in a different folder structure, then you should define JOOMLA_PATH_BASE manually in your qa-config file.
+     */
+    private function find_joomla_path()
+    {
+        if (!defined('JPATH_BASE')) {   //JPATH_BASE must be defined for Joomla to work.
+            $joomlaPath = dirname(dirname(dirname(__DIR__)));
+            define('JPATH_BASE', $joomlaPath);
+        }
+    }
+
+    private function load_joomla_app()
+    {
+        define( '_JEXEC', 1 ); //This will define the _JEXEC constant that will allow us to access the rest of the Joomla framework
+        require_once(JPATH_BASE.'/includes/defines.php' );
+        require_once(JPATH_BASE.'/includes/framework.php' );
+        // Instantiate the application.
+        $this->app = JFactory::getApplication('site');
+        // Initialise the application.
+        $this->app->initialise();
+    }
+
+    public function get_app()
+    {
+        return $this->app;
+    }
+
+    public function get_user($userid = null)
+    {
+        return JFactory::getUser($userid);
+    }
+
+    public function get_userid($username)
+    {
+        JUserHelper::getUserId($username);
+    }
+
+    function trigger_access_event($user)
+    {
+        return $this->trigger_joomla_event('onQnaAccess', [$user]);
+    }
+    function trigger_team_group_event($user)
+    {
+        return $this->trigger_joomla_event('onTeamGroup', [$user]);
+    }
+    function trigger_get_urls_event()
+    {
+        return $this->trigger_joomla_event('onGetURLs', []);
+    }
+    function trigger_get_avatar_event($userid, $size)
+    {
+        return $this->trigger_joomla_event('onGetAvatar', [$userid, $size]);
+    }
+    function trigger_log_event($userid, $action)
+    {
+        return $this->trigger_joomla_event('onWriteLog', [$userid, $action], false);
+    }
+
+    private function trigger_joomla_event($event, $args = [], $expectResponse = true)
+    {
+        JPluginHelper::importPlugin('q2a');
+        $dispatcher = JEventDispatcher::getInstance();
+        $results = $dispatcher->trigger($event, $args);
+
+        if ($expectResponse && (!is_array($results) || count($results) < 1)) {
+            //no Q2A plugins installed in Joomla, so we'll have to resort to defaults
+            $results = $this->default_response($event, $args);
+        }
+        return array_pop($results);
+    }
+    private function default_response($event, $args)
+    {
+        return array(qa_joomla_default_integration::$event($args));
+    }
+}
+
+/**
+ * Implements the same methods as a Joomla plugin would implement, but called locally within Q2A.
+ * This is intended as a set of default actions in case no Joomla plugin has been installed.
+ * (Installing a Joomla plugin is recommended however, as there is a lot more flexibility that way)
+ * Note that the implementation of these methods is not the same as it would be in a Joomla plugin, so please don't use it to crib from to create one! Use the actual Joomla Q2A Integration plugin instead.
+ */
+class qa_joomla_default_integration
+{
+    /**
+     * If you're relying on the defaults, you must make sure that your Joomla instance has the following pages configured.
+     */
+    public static function onGetURLs()
+    {
+        return array(
+            'login'  => '/login.html',
+            'logout' => '/logout.html',
+            'reg'    => '/register.html',
+            'denied' => '/',
+        );
+    }
+
+    /**
+     * Return the access levels available to the user. A proper Joomla plugin would allow you to fine tune this in as much
+     * detail as you needed, but this default method can only look at the core Joomla system permissions and try to map
+     * those to the Q2A perms. Not ideal; enough to get started, but recommend switching to the Joomla plugin if possible.
+     */
+    public static function onQnaAccess(array $args)
+    {
+        list($user) = $args;
+
+        return array(
+            'view' => !($user->guest || $user->block),
+            'post' => !($user->guest || $user->block),
+            'edit' => $user->authorise('core.edit'),
+            'mod'  => $user->authorise('core.edit.state'),
+            'admin'=> $user->authorise('core.manage'),
+            'super'=> $user->authorise('core.admin') || $user->get('isRoot'),
+        );
+    }
+
+    /**
+     * Return the group name (if any) that was responsible for granting the user access to the given view level.
+     * For this default method, we just won't return anything.
+     */
+    public static function onTeamGroup($args)
+    {
+        list($user) = $args;
+        return null;
+    }
+
+    /**
+     * This method would be used to ask Joomla to supply an avatar for a user.
+     * For this default method, we just won't do anything.
+     */
+    public static function onGetAvatar($args)
+    {
+        list($userid, $size) = $args;
+        return null;
+    }
+
+    /**
+     * This method would be used to notify Joomla of a Q2A action, eg so it could write a log entry.
+     * For this default method, we just won't do anything.
+     */
+    public static function onWriteLog($args)
+    {
+        list($userid, $action) = $args;
+        return null;
+    }
+}
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/


### PR DESCRIPTION
These changes implement out-of-the-box integration with Joomla!, in a similar vein to the existing Wordpress integration.

In addition to these changes, the Joomla! integration also requires a plugin to be installed into Joomla! (see https://github.com/SFWLtd/plg_q2a_integration). This plugin allows the Joomla! administrator to configure the Joomla! permissions that will grant different levels of access to Q2A.

Note that the installation instructions on the Joomla! plugin currently describe how to install it with a version of Q2A that does not contain the changes in this pull request. The changes here will allow those installation instructions to be dramatically simplified.