### PR TITLE
Change from / reply-to for feedback form

### DIFF
--- a/qa-include/app/emails.php
+++ b/qa-include/app/emails.php
@@ -130,7 +130,7 @@
 		$mailer->From=$params['fromemail'];
 		$mailer->Sender=$params['fromemail'];
 		$mailer->FromName=$params['fromname'];
-		$mailer->AddAddress($params['toemail'], $params['toname']);
+		$mailer->addAddress($params['toemail'], $params['toname']);
 		if(!empty($params['replytoemail'])){
 			$mailer->addReplyTo($params['replytoemail'], $params['replytoname']);
 		}
@@ -138,10 +138,10 @@
 		$mailer->Body=$params['body'];
 
 		if ($params['html'])
-			$mailer->IsHTML(true);
+			$mailer->isHTML(true);
 
 		if (qa_opt('smtp_active')) {
-			$mailer->IsSMTP();
+			$mailer->isSMTP();
 			$mailer->Host=qa_opt('smtp_address');
 			$mailer->Port=qa_opt('smtp_port');
 
@@ -165,7 +165,7 @@
 			}
 		}
 
-		$send_status = $mailer->Send();
+		$send_status = $mailer->send();
 		if(!$send_status){
 			@error_log('PHP Question2Answer email send error: '.$mailer->ErrorInfo);
 		}

--- a/qa-include/app/emails.php
+++ b/qa-include/app/emails.php
@@ -131,6 +131,9 @@
 		$mailer->Sender=$params['fromemail'];
 		$mailer->FromName=$params['fromname'];
 		$mailer->AddAddress($params['toemail'], $params['toname']);
+		if(!empty($params['replytoemail'])){
+			$mailer->addReplyTo($params['replytoemail'], $params['replytoname']);
+		}
 		$mailer->Subject=$params['subject'];
 		$mailer->Body=$params['body'];
 

--- a/qa-include/pages/feedback.php
+++ b/qa-include/pages/feedback.php
@@ -89,8 +89,10 @@
 				);
 
 				if (qa_send_email(array(
-					'fromemail' => qa_email_validate(@$inemail) ? $inemail : qa_opt('from_email'),
+					'fromemail' => qa_opt('from_email'),
 					'fromname' => $inname,
+					'replytoemail' => qa_email_validate(@$inemail) ? $inemail : null,
+					'replytoname' => $inname,
 					'toemail' => qa_opt('feedback_email'),
 					'toname' => qa_opt('site_title'),
 					'subject' => qa_lang_sub('emails/feedback_subject', qa_opt('site_title')),


### PR DESCRIPTION
If the email address user inputed has forced SPF check, the email will not be received by major ESPs unless it is put in `Reply-to` field instead of `From` field.