### PR TITLE
Making headline text accessible for CSS

### DIFF
--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -723,11 +723,16 @@ class qa_html_theme_base
 		$url = isset($q_view['url']) ? $q_view['url'] : false;
 
 		if (isset($this->content['title'])) {
-			$this->output(
-				$url ? '<a href="'.$url.'">' : '',
-				$this->content['title'],
-				$url ? '</a>' : ''
-			);
+			if($url) {
+				$this->output(
+					'<a href="'.$url.'">'.$this->content['title'].'</a>'
+				);
+			}
+			else {
+				$this->output(
+					'<span class="headlinespan">'.$this->content['title'].'</span>'
+				);
+			}
 		}
 
 		// add closed note in title


### PR DESCRIPTION
If the text within the H1 does not have a span with class, it cannot be selected separately.
