### PR TITLE
Fix double slash in default site_url option

### DIFF
--- a/qa-include/app/options.php
+++ b/qa-include/app/options.php
@@ -365,7 +365,7 @@
 		else
 			switch ($name) {
 				case 'site_url':
-					$value='http://'.@$_SERVER['HTTP_HOST'].strtr(dirname($_SERVER['SCRIPT_NAME']), '\\', '/').'/';
+					$value='http://'.@$_SERVER['HTTP_HOST'].strtr(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'), '\\', '/').'/';
 					break;
 
 				case 'site_title':


### PR DESCRIPTION
When `$_SERVER['SCRIPT_NAME']` is at the root such as `/index.php` then calling `qa_default_option('site_url')` generates a double slash. This commit removes it.
