### PR TITLE
Add ability to disable plugins

### DIFF
--- a/qa-content/qa-admin.js
+++ b/qa-content/qa-admin.js
@@ -145,3 +145,15 @@ function qa_version_check(uri, version, elem)
 		}
 	);
 }
+
+function qa_get_enabled_plugins_hashes()
+{
+	var hashes = [];
+	$('[id^=plugin_enabled]:checked').each(
+		function (idx, elem) {
+			hashes.push(elem.id.replace("plugin_enabled_", ""));
+		}
+	);
+
+	$('[name=enabled_plugins_hashes]').val(hashes.join(';'));
+}

--- a/qa-include/Q2A/Plugin/PluginManager.php
+++ b/qa-include/Q2A/Plugin/PluginManager.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+	Question2Answer by Gideon Greenspan and contributors
+	http://www.question2answer.org/
+
+	File: qa-include/Q2A/Plugin/PluginManager.php
+	Description: Keeps track of the installed plugins
+
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	More about this license: http://www.question2answer.org/license.php
+*/
+
+class Q2A_Plugin_PluginManager
+{
+	const PLUGIN_DELIMITER = ';';
+	const OPT_ENABLED_PLUGINS = 'enabled_plugins';
+
+	public function getEnabledPlugins($fullPath = false)
+	{
+		$pluginDirectories = $this->getEnabledPluginsOption();
+
+		if ($fullPath) {
+			foreach ($pluginDirectories as $key => &$pluginDirectory)
+				$pluginDirectory = QA_PLUGIN_DIR . $pluginDirectory . '/';
+		}
+
+		return $pluginDirectories;
+	}
+
+	public function setEnabledPlugins($array)
+	{
+		$this->setEnabledPluginsOption($array);
+	}
+
+	public function getFilesystemPlugins($fullPath = false)
+	{
+		$result = array();
+
+		$fileSystemPluginFiles = glob(QA_PLUGIN_DIR . '*/qa-plugin.php');
+
+		foreach ($fileSystemPluginFiles as $pluginFile) {
+			$directory = dirname($pluginFile);
+
+			if (!$fullPath) {
+				$directory = basename($directory);
+			}
+			$result[] = $directory;
+		}
+
+		return $result;
+	}
+
+	public function getHashesForPlugins($pluginDirectories)
+	{
+		$result = array();
+
+		foreach ($pluginDirectories as $pluginDirectory) {
+			$result[$pluginDirectory] = md5($pluginDirectory);
+		}
+
+		return $result;
+	}
+
+	private function getEnabledPluginsOption()
+	{
+		return explode(self::PLUGIN_DELIMITER, qa_opt(self::OPT_ENABLED_PLUGINS));
+	}
+
+	private function setEnabledPluginsOption($array)
+	{
+		qa_opt(self::OPT_ENABLED_PLUGINS, implode(self::PLUGIN_DELIMITER, $array));
+	}
+
+	public function cleanRemovedPlugins()
+	{
+		$finalEnabledPlugins = array_intersect(
+			$this->getFilesystemPlugins(),
+			$this->getEnabledPlugins()
+		);
+
+		$this->setEnabledPluginsOption($finalEnabledPlugins);
+	}
+}

--- a/qa-include/app/admin.php
+++ b/qa-include/app/admin.php
@@ -608,7 +608,10 @@
 	 */
 	function qa_admin_plugin_directory_hash($directory)
 	{
-		return md5($directory);
+		$pluginManager = new Q2A_Plugin_PluginManager();
+		$hashes = $pluginManager->getHashesForPlugins(array($directory));
+
+		return reset($hashes);
 	}
 
 

--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -25,7 +25,7 @@
 		exit;
 	}
 
-	define('QA_DB_VERSION_CURRENT', 63);
+	define('QA_DB_VERSION_CURRENT', 64);
 
 
 	function qa_db_user_column_type_verify()
@@ -1516,6 +1516,13 @@
 
 					qa_db_upgrade_query($locktablesquery);
 					break;
+
+                case 64:
+					$pluginManager = new Q2A_Plugin_PluginManager();
+					$allPlugins = $pluginManager->getFilesystemPlugins();
+					$pluginManager->setEnabledPlugins($allPlugins);
+					break;
+
 
 			//	Up to here: Version 1.8 alpha
 			}

--- a/qa-include/lang/qa-lang-admin.php
+++ b/qa-include/lang/qa-lang-admin.php
@@ -105,6 +105,7 @@
 		'edit_title' => ' - ^1edit title^2',
 		'emails_per_minute' => 'emails per minute',
 		'emails_title' => 'Emails',
+		'enabled' => 'Enabled',
 		'feed_link' => 'Feed',
 		'feed_link_example' => 'Example feed',
 		'feeds_title' => 'RSS feeds',

--- a/qa-include/pages/admin/admin-plugins.php
+++ b/qa-include/pages/admin/admin-plugins.php
@@ -69,13 +69,21 @@ $qa_content['error'] = qa_admin_page_error();
 
 $qa_content['script_rel'][] = 'qa-content/qa-admin.js?' . QA_VERSION;
 
-$pluginfiles = glob(QA_PLUGIN_DIR . '*/qa-plugin.php');
+
+$pluginManager = new Q2A_Plugin_PluginManager();
+$pluginManager->cleanRemovedPlugins();
+
+$enabledPlugins = $pluginManager->getEnabledPlugins();
+$fileSystemPlugins = $pluginManager->getFilesystemPlugins();
+
+$pluginHashes = $pluginManager->getHashesForPlugins($fileSystemPlugins);
 
 foreach ($moduletypes as $type) {
 	$modules = qa_load_modules_with($type, 'init_queries');
 
 	foreach ($modules as $name => $module) {
 		$queries = $module->init_queries($tables);
+
 
 		if (!empty($queries)) {
 			if (qa_is_http_post())
@@ -93,19 +101,32 @@ foreach ($moduletypes as $type) {
 	}
 }
 
-if (qa_is_http_post() && !qa_check_form_security_code('admin/plugins', qa_post_text('qa_form_security_code'))) {
-	$qa_content['error'] = qa_lang_html('misc/form_security_reload');
-	$showpluginforms = false;
-} else
-	$showpluginforms = true;
+$showpluginforms = true;
+if (qa_is_http_post()) {
+	if (!qa_check_form_security_code('admin/plugins', qa_post_text('qa_form_security_code'))) {
+		$qa_content['error'] = qa_lang_html('misc/form_security_reload');
+		$showpluginforms = false;
+	} else {
+		if (qa_clicked('dosave')) {
+			$enabledPluginHashes = qa_post_text('enabled_plugins_hashes');
+			$enabledPluginHashesArray = explode(';', $enabledPluginHashes);
+			$pluginDirectories = array_keys(array_intersect($pluginHashes, $enabledPluginHashesArray));
+			$pluginManager->setEnabledPlugins($pluginDirectories);
 
-if (!empty($pluginfiles)) {
+			qa_redirect('admin/plugins');
+		}
+	}
+}
+
+if (!empty($fileSystemPlugins)) {
 	$metadataUtil = new Q2A_Util_Metadata();
 	$sortedPluginFiles = array();
 
-	foreach ($pluginfiles as $pluginFile) {
-		$metadata = $metadataUtil->fetchFromAddonPath(dirname($pluginFile));
+	foreach ($fileSystemPlugins as $pluginDirectory) {
+		$metadata = $metadataUtil->fetchFromAddonPath($pluginDirectory);
 		if (empty($metadata)) {
+			$pluginFile = QA_PLUGIN_DIR . $pluginDirectory . '/qa-plugin.php';
+
 			// limit plugin parsing to first 8kB
 			$contents = file_get_contents($pluginFile, false, null, -1, 8192);
 			$metadata = qa_addon_metadata($contents, 'Plugin');
@@ -113,16 +134,17 @@ if (!empty($pluginfiles)) {
 		$metadata['name'] = isset($metadata['name']) && !empty($metadata['name'])
 			? qa_html($metadata['name'])
 			: qa_lang_html('admin/unnamed_plugin');
-		$sortedPluginFiles[$pluginFile] = $metadata;
+		$sortedPluginFiles[$pluginDirectory] = $metadata;
 	}
 
 	qa_sort_by($sortedPluginFiles, 'name');
 
 	$pluginIndex = -1;
-	foreach ($sortedPluginFiles as $pluginFile => $metadata) {
+	foreach ($sortedPluginFiles as $pluginDirectory => $metadata) {
 		$pluginIndex++;
-		$plugindirectory = dirname($pluginFile);
-		$hash = qa_admin_plugin_directory_hash($plugindirectory);
+
+		$pluginDirectoryPath = QA_PLUGIN_DIR . $pluginDirectory;
+		$hash = $pluginHashes[$pluginDirectory];
 		$showthisform = $showpluginforms && (qa_get('show') == $hash);
 
 		$namehtml = $metadata['name'];
@@ -148,7 +170,7 @@ if (!empty($pluginfiles)) {
 			$authorhtml = '';
 
 		if ($metaver && isset($metadata['update_uri']) && strlen($metadata['update_uri'])) {
-			$elementid = 'version_check_' . md5($plugindirectory);
+			$elementid = 'version_check_' . md5($pluginDirectory);
 
 			$updatehtml = '(<span id="' . $elementid . '">...</span>)';
 
@@ -164,12 +186,15 @@ if (!empty($pluginfiles)) {
 		else
 			$deschtml = '';
 
-		if (isset($pluginoptionmodules[$plugindirectory]) && !$showthisform)
-			$deschtml .= (strlen($deschtml) ? ' - ' : '').'<a href="'.
-				qa_admin_plugin_options_path($plugindirectory).'">'.qa_lang_html('admin/options').'</a>';
+		if (isset($pluginoptionmodules[$pluginDirectoryPath]) && !$showthisform) {
+			$deschtml .= (strlen($deschtml) ? ' - ' : '') . '<a href="' . qa_admin_plugin_options_path($pluginDirectory) . '">' .
+				qa_lang_html('admin/options') . '</a>';
+		}
 
-		$pluginhtml = $namehtml.' '.$authorhtml.' '.$updatehtml.'<br>'.$deschtml.(strlen($deschtml) ? '<br>' : '').
-			'<small style="color:#666">'.qa_html($plugindirectory).'/</small>';
+		$enabled = in_array($pluginDirectory, $enabledPlugins);
+		$pluginhtml = $namehtml . ' ' . $authorhtml . ' ' . $updatehtml . '<br>';
+		$pluginhtml .= $deschtml . (strlen($deschtml) > 0 ? '<br>' : '');
+		$pluginhtml .= '<small style="color:#666">' . qa_html($pluginDirectoryPath) . '/</small>';
 
 		if (qa_qa_version_below(@$metadata['min_q2a']))
 			$pluginhtml = '<s style="color:#999">'.$pluginhtml.'</s><br><span style="color:#f00">'.
@@ -184,14 +209,20 @@ if (!empty($pluginfiles)) {
 			'style' => 'tall',
 			'fields' => array(
 				array(
+					'type' => 'checkbox',
+					'label' => qa_lang_html('admin/enabled'),
+					'value' => $enabled,
+					'tags' => sprintf('id="plugin_enabled_%s"', $hash),
+				),
+				array(
 					'type' => 'custom',
 					'html' => $pluginhtml,
-				)
+				),
 			),
 		);
 
-		if ($showthisform && isset($pluginoptionmodules[$plugindirectory])) {
-			foreach ($pluginoptionmodules[$plugindirectory] as $pluginoptionmodule) {
+		if ($showthisform && isset($pluginoptionmodules[$pluginDirectoryPath])) {
+			foreach ($pluginoptionmodules[$pluginDirectoryPath] as $pluginoptionmodule) {
 				$type = $pluginoptionmodule['type'];
 				$name = $pluginoptionmodule['name'];
 
@@ -200,7 +231,7 @@ if (!empty($pluginfiles)) {
 				$form = $module->admin_form($qa_content);
 
 				if (!isset($form['tags']))
-					$form['tags'] = 'method="post" action="' . qa_admin_plugin_options_path($plugindirectory) . '"';
+					$form['tags'] = 'method="post" action="' . qa_admin_plugin_options_path($pluginDirectory) . '"';
 
 				if (!isset($form['style']))
 					$form['style'] = 'tall';
@@ -216,6 +247,24 @@ if (!empty($pluginfiles)) {
 }
 
 $qa_content['navigation']['sub'] = qa_admin_sub_navigation();
+
+$qa_content['form'] = array(
+	'tags' => 'method="post" action="' . qa_self_html() . '" name="plugins_form" onsubmit="qa_get_enabled_plugins_hashes(); return true;"',
+
+	'style' => 'wide',
+
+	'buttons' => array(
+		'dosave' => array(
+			'tags' => 'name="dosave"',
+			'label' => qa_lang_html('admin/save_options_button'),
+		),
+	),
+
+	'hidden' => array(
+		'qa_form_security_code' => qa_get_form_security_code('admin/plugins'),
+		'enabled_plugins_hashes' => '',
+	),
+);
 
 
 return $qa_content;

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -58,15 +58,18 @@
 		require_once QA_JOOMLA_LOAD_FILE;
 	}
 
+
 	qa_initialize_constants_2();
 	qa_initialize_modularity();
 	qa_register_core_modules();
-	qa_load_plugin_files();
 	qa_load_override_files();
 
 	require_once QA_INCLUDE_DIR.'qa-db.php';
 
 	qa_db_allow_connect();
+
+	qa_load_plugin_files();
+
 
 
 //	Version comparison functions
@@ -399,16 +402,20 @@
 	{
 		global $qa_plugin_directory, $qa_plugin_urltoroot;
 
-		$pluginfiles = glob(QA_PLUGIN_DIR.'*/qa-plugin.php');
+		$pluginManager = new Q2A_Plugin_PluginManager();
+		$pluginDirectories = $pluginManager->getEnabledPlugins(true);
 
 		$metadataUtil = new Q2A_Util_Metadata();
-		foreach ($pluginfiles as $pluginfile) {
-			$pluginDirectory = dirname($pluginfile);
+		foreach ($pluginDirectories as $pluginDirectory) {
+			$pluginFile = $pluginDirectory . 'qa-plugin.php';
 
-			$metadata = $metadataUtil->fetchFromAddonPath($pluginDirectory);
+			if (!file_exists($pluginFile))
+				continue;
+
+			$metadata = $metadataUtil->fetchFromAddonPath($qa_plugin_directory);
 			if (empty($metadata)) {
 				// limit plugin parsing to first 8kB
-				$contents = file_get_contents($pluginfile, false, null, -1, 8192);
+				$contents = file_get_contents($pluginFile, false, null, -1, 8192);
 				$metadata = qa_addon_metadata($contents, 'Plugin', true);
 			}
 
@@ -420,10 +427,10 @@
 				continue;
 
 			// these variables are utilized in the qa_register_plugin_* functions
-			$qa_plugin_directory = $pluginDirectory . '/';
+			$qa_plugin_directory = $pluginDirectory;
 			$qa_plugin_urltoroot = substr($qa_plugin_directory, strlen(QA_BASE_DIR));
 
-			require_once $pluginfile;
+			require_once $pluginFile;
 		}
 
 		$qa_plugin_directory = null;


### PR DESCRIPTION
I think the subject says it all. There are a few things to bear in mind, though.
- The code is a bit dirty and undocumented (writing the doc takes almost the same time as developing this so I'm waiting for some feedback before doing that).
- Plugins that are disabled should not even register because if they do so they'd execute the `qa-plugin.php` code and the main idea is not to execute that file. This generates a possibly undesired behaviour when showing plugin specific options as the "options" link comes from executing the plugin's code.
- Additionally, some code had to be slightly reordered so that the `init_queries` function doesn't get called either.
- In order to avoid the object creation overhead in `qa_admin_plugin_directory_hash`, the `getHashesForPlugins` method could be made static. But as this complicates testing and doesn't go along dependency injection I kept it that way. It could also be made singleton but still I didn't like the idea, at least until we have an IoC container (in Q2a 3.0, of course) :)
- 'qa_opt' does not allow to check for the presence of a value without creating the key/title (this should be changed IMO). So maybe the initialization of the `enabled_plugins` option might be executed during database initialization. I haven't implemented this yet either.

![screenshot](https://cloud.githubusercontent.com/assets/1449790/19428759/474eb944-9422-11e6-982f-cfa16374b9e9.png)
