### PR TITLE
Improved Forgot Password Procedure

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1646,11 +1646,13 @@
 	$inname is from previous submission/validation. Pass $fieldprefix to add a prefix to the form field name used.
 */
 	{
-		$fields['name']=array(
-			'label' => qa_lang_html('question/anon_name_label'),
-			'tags' => 'name="'.$fieldprefix.'name"',
-			'value' => qa_html($inname),
-		);
+		if(qa_opt('allow_anonymous_naming')) {
+			$fields['name']=array(
+				'label' => qa_lang_html('question/anon_name_label'),
+				'tags' => 'name="'.$fieldprefix.'name"',
+				'value' => qa_html($inname),
+			);
+		}
 	}
 
 

--- a/qa-include/app/options.php
+++ b/qa-include/app/options.php
@@ -202,6 +202,7 @@
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		$fixed_defaults=array(
+			'allow_anonymous_naming' => 1,
 			'allow_change_usernames' => 1,
 			'allow_close_questions' => 1,
 			'allow_multi_answers' => 1,

--- a/qa-include/lang/qa-lang-emails.php
+++ b/qa-include/lang/qa-lang-emails.php
@@ -65,7 +65,7 @@
 		'remoderate_body' => "An edited post by ^p_handle requires your reapproval:\n\n^open^p_context^close\n\nClick below to approve or hide the edited post:\n\n^url\n\n\nClick below to review all queued posts:\n\n^a_url\n\n\nThank you,\n\n^site_title",
 		'remoderate_subject' => '^site_title moderation',
 
-		'reset_body' => "Please click below to reset your password for ^site_title.\n\n^url\n\nAlternatively, enter the code below into the field provided.\n\nCode: ^code\n\nIf you did not ask to reset your password, please ignore this message.\n\nThank you,\n^site_title",
+		'reset_body' => "Please click below to reset your password for ^site_title.\n\n^url\n\nIf you did not ask to reset your password, please ignore this message.\n\nThank you,\n^site_title",
 		'reset_subject' => '^site_title - Reset Forgotten Password',
 
 		'to_handle_prefix' => "^,\n\n",

--- a/qa-include/lang/qa-lang-options.php
+++ b/qa-include/lang/qa-lang-options.php
@@ -21,6 +21,7 @@
 */
 
 	return array(
+		'allow_anonymous_naming' => 'Allow anonymous posters to specify their name:',
 		'allow_change_usernames' => 'Allow users with posts to change their username:',
 		'allow_close_questions' => 'Allow questions to be manually closed:',
 		'allow_login_email_only' => 'Only log in by email address (not username):',

--- a/qa-include/lang/qa-lang-question.php
+++ b/qa-include/lang/qa-lang-question.php
@@ -76,7 +76,7 @@
 		'close_original_note' => 'You can also enter the question number from the URL, e.g. 123.',
 		'close_original_title' => 'URL of the original question:',
 		'close_q_popup' => 'Close this question to any new answers',
-		'close_reason_title' => 'Reason for closing this question:',
+		'close_reason_title' => 'Reason for closing this question or insert the URL of the duplicate question:',
 		'closed_as_duplicate' => 'closed as a duplicate of:',
 		'closed_with_note' => 'closed with the note:',
 		'comment_a_popup' => 'Add a comment on this answer',

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -131,6 +131,7 @@
 		'show_full_date_days' => 'number',
 		'smtp_port' => 'number',
 
+		'allow_anonymous_naming' => 'checkbox',
 		'allow_change_usernames' => 'checkbox',
 		'allow_close_questions' => 'checkbox',
 		'allow_login_email_only' => 'checkbox',
@@ -439,7 +440,7 @@
 
 			$subtitle = 'admin/posting_title';
 
-			$showoptions = array('do_close_on_select', 'allow_close_questions', 'allow_self_answer', 'allow_multi_answers', 'follow_on_as', 'comment_on_qs', 'comment_on_as', '');
+			$showoptions = array('do_close_on_select', 'allow_close_questions', 'allow_self_answer', 'allow_multi_answers', 'allow_anonymous_naming', 'follow_on_as', 'comment_on_qs', 'comment_on_as', '');
 
 			if (count(qa_list_modules('editor'))>1)
 				array_push($showoptions, 'editor_for_qs', 'editor_for_as', 'editor_for_cs', '');

--- a/qa-include/pages/login.php
+++ b/qa-include/pages/login.php
@@ -111,49 +111,58 @@
 
 	$forgothtml='<a href="'.qa_html($forgotpath).'">'.qa_lang_html('users/forgot_link').'</a>';
 
-	$qa_content['form']=array(
-		'tags' => 'method="post" action="'.qa_self_html().'"',
+	if($passwordsent)
+	{
+		$qa_content['error'] = qa_lang_html('users/password_sent');
+		$qa_content['custom'] = '<a class="qa-form-wide-button" href="'.qa_path('login').'?e='.$inemailhandle.'">'.qa_lang_html('users/login_button').'</a>';
+	}
+	else
+	{
+		$qa_content['form']=array(
+			'tags' => 'method="post" action="'.qa_self_html().'"',
 
-		'style' => 'tall',
+			'style' => 'tall',
 
-		'ok' => $passwordsent ? qa_lang_html('users/password_sent') : ($emailexists ? qa_lang_html('users/email_exists') : null),
+			// 'ok' => $passwordsent ? qa_lang_html('users/password_sent') : ($emailexists ? qa_lang_html('users/email_exists') : null),
+			'ok' => ($emailexists ? qa_lang_html('users/email_exists') : null),
 
-		'fields' => array(
-			'email_handle' => array(
-				'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
-				'tags' => 'name="emailhandle" id="emailhandle" dir="auto"',
-				'value' => qa_html(@$inemailhandle),
-				'error' => qa_html(@$errors['emailhandle']),
+			'fields' => array(
+				'email_handle' => array(
+					'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
+					'tags' => 'name="emailhandle" id="emailhandle" dir="auto"',
+					'value' => qa_html(@$inemailhandle),
+					'error' => qa_html(@$errors['emailhandle']),
+				),
+
+				'password' => array(
+					'type' => 'password',
+					'label' => qa_lang_html('users/password_label'),
+					'tags' => 'name="password" id="password" dir="auto"',
+					'value' => qa_html(@$inpassword),
+					'error' => empty($errors['password']) ? '' : (qa_html(@$errors['password']).' - '.$forgothtml),
+					'note' => $passwordsent ? qa_lang_html('users/password_sent') : $forgothtml,
+				),
+
+				'remember' => array(
+					'type' => 'checkbox',
+					'label' => qa_lang_html('users/remember_label'),
+					'tags' => 'name="remember"',
+					'value' => !empty($inremember),
+				),
 			),
 
-			'password' => array(
-				'type' => 'password',
-				'label' => qa_lang_html('users/password_label'),
-				'tags' => 'name="password" id="password" dir="auto"',
-				'value' => qa_html(@$inpassword),
-				'error' => empty($errors['password']) ? '' : (qa_html(@$errors['password']).' - '.$forgothtml),
-				'note' => $passwordsent ? qa_lang_html('users/password_sent') : $forgothtml,
+			'buttons' => array(
+				'login' => array(
+					'label' => qa_lang_html('users/login_button'),
+				),
 			),
 
-			'remember' => array(
-				'type' => 'checkbox',
-				'label' => qa_lang_html('users/remember_label'),
-				'tags' => 'name="remember"',
-				'value' => !empty($inremember),
+			'hidden' => array(
+				'dologin' => '1',
+				'code' => qa_get_form_security_code('login'),
 			),
-		),
-
-		'buttons' => array(
-			'login' => array(
-				'label' => qa_lang_html('users/login_button'),
-			),
-		),
-
-		'hidden' => array(
-			'dologin' => '1',
-			'code' => qa_get_form_security_code('login'),
-		),
-	);
+		);
+	}
 
 	$loginmodules=qa_load_modules_with('login', 'login_html');
 

--- a/qa-include/pages/question-post.php
+++ b/qa-include/pages/question-post.php
@@ -528,19 +528,10 @@
 			'title' => qa_lang_html('question/close_form_title'),
 
 			'fields' => array(
-				'duplicate' => array(
-					'type' => 'checkbox',
-					'tags' => 'name="q_close_duplicate" id="q_close_duplicate" onchange="document.getElementById(\'q_close_details\').focus();"',
-					'label' => qa_lang_html('question/close_duplicate'),
-					'value' => @$in['duplicate'],
-				),
-
 				'details' => array(
 					'tags' => 'name="q_close_details" id="q_close_details"',
 					'label' =>
-						'<span id="close_label_duplicate">'.qa_lang_html('question/close_original_title').' </span>'.
-						'<span id="close_label_other">'.qa_lang_html('question/close_reason_title').'</span>',
-					'note' => '<span id="close_note_duplicate" style="display:none;">'.qa_lang_html('question/close_original_note').'</span>',
+						'<span id="close_label_other">'.qa_lang_html('question/close_reason_title').':</span>',
 					'value' => @$in['details'],
 					'error' => qa_html(@$errors['details']),
 				),
@@ -564,12 +555,6 @@
 			),
 		);
 
-		qa_set_display_rules($qa_content, array(
-			'close_label_duplicate' => 'q_close_duplicate',
-			'close_label_other' => '!q_close_duplicate',
-			'close_note_duplicate' => 'q_close_duplicate',
-		));
-
 		$qa_content['focusid']='q_close_details';
 
 		return $form;
@@ -582,18 +567,19 @@
 */
 	{
 		$in=array(
-			'duplicate' => qa_post_text('q_close_duplicate'),
-			'details' => qa_post_text('q_close_details'),
+			'details' => trim(qa_post_text('q_close_details')),
 		);
 
 		$userid=qa_get_logged_in_userid();
 		$handle=qa_get_logged_in_handle();
 		$cookieid=qa_cookie_get();
 
-		if (!qa_check_form_security_code('close-'.$question['postid'], qa_post_text('code')))
-			$errors['details']=qa_lang_html('misc/form_security_again');
-
-		elseif ($in['duplicate']) {
+		$isduplicateurl = filter_var($in['details'], FILTER_VALIDATE_URL);
+		
+		if (!qa_check_form_security_code('close-'.$question['postid'], qa_post_text('code'))) {
+			$errors['details']=qa_lang_html('misc/form_security_again');			
+		}
+		elseif ($isduplicateurl) {
 			// be liberal in what we accept, but there are two potential unlikely pitfalls here:
 			// a) URLs could have a fixed numerical path, e.g. http://qa.mysite.com/1/478/...
 			// b) There could be a question title which is just a number, e.g. http://qa.mysite.com/478/12345/...

--- a/qa-include/pages/reset.php
+++ b/qa-include/pages/reset.php
@@ -20,7 +20,9 @@
 	More about this license: http://www.question2answer.org/license.php
 */
 
-	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	// don't allow this page to be requested directly from browser
+	if (!defined('QA_VERSION'))
+	{ 
 		header('Location: ../');
 		exit;
 	}
@@ -28,109 +30,167 @@
 
 //	Check we're not using single-sign on integration and that we're not logged in
 
-	if (QA_FINAL_EXTERNAL_USERS)
-		qa_fatal_error('User login is handled by external code');
+	if (QA_FINAL_EXTERNAL_USERS) 
+	{
+		qa_fatal_error('User login is handled by external code');			
+	}
 
 	if (qa_is_logged_in())
-		qa_redirect('');
+	{
+		qa_redirect('');			
+	}
 
 
+	$dosubmitform = false;
+	$showmsg_checkmail = false;
+	
 //	Process incoming form
 
-	if (qa_clicked('doreset')) {
+	if (qa_clicked('doreset')) 
+	{
 		require_once QA_INCLUDE_DIR.'app/users-edit.php';
 		require_once QA_INCLUDE_DIR.'db/users.php';
 
-		$inemailhandle=qa_post_text('emailhandle');
-		$incode=trim(qa_post_text('code')); // trim to prevent passing in blank values to match uninitiated DB rows
+		$inemailhandle = qa_post_text('emailhandle');
+		// trim to prevent passing in blank values to match uninitiated DB rows
+		$incode = trim(qa_post_text('code')); 
 
-		$errors=array();
+		$errors = array();
 
-		if (!qa_check_form_security_code('reset', qa_post_text('formcode')))
-			$errors['page']=qa_lang_html('misc/form_security_again');
-
-		else {
-			if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@')!==false)) // handles can't contain @ symbols
-				$matchusers=qa_db_user_find_by_email($inemailhandle);
-			else
-				$matchusers=qa_db_user_find_by_handle($inemailhandle);
-
-			if (count($matchusers)==1) { // if match more than one (should be impossible), consider it a non-match
-				require_once QA_INCLUDE_DIR.'db/selects.php';
-
-				$inuserid=$matchusers[0];
-				$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
-
-				// strlen() check is vital otherwise we can reset code for most users by entering the empty string
-				if (strlen($incode) && (strtolower(trim($userinfo['emailcode'])) == strtolower($incode))) {
-					qa_complete_reset_user($inuserid);
-					qa_redirect('login', array('e' => $inemailhandle, 'ps' => '1')); // redirect to login page
-
-				} else
-					$errors['code']=qa_lang('users/reset_code_wrong');
-
-			} else
-				$errors['emailhandle']=qa_lang('users/user_not_found');
+		if (!qa_check_form_security_code('reset', qa_post_text('formcode'))) 
+		{
+			$errors['page'] = qa_lang_html('misc/form_security_again');
 		}
+		else 
+		{
+			if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@')!==false)) // handles can't contain @ symbols
+			{
+				$matchusers = qa_db_user_find_by_email($inemailhandle);
+			}
+			else
+			{
+				$matchusers = qa_db_user_find_by_handle($inemailhandle);					
+			}
 
-	} else {
-		$inemailhandle=qa_get('e');
-		$incode=qa_get('c');
+			// if match more than one (should be impossible), consider it a non-match
+			if (count($matchusers)==1) 
+			{
+				require_once QA_INCLUDE_DIR.'db/selects.php';
+				
+				$inuserid = $matchusers[0];
+				$userinfo = qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
+				
+				// strlen() check is vital otherwise we can reset code for most users by entering the empty string
+				if (strlen($incode) && (strtolower(trim($userinfo['emailcode'])) == strtolower($incode))) 
+				{
+					qa_complete_reset_user($inuserid);
+					// redirect to login page
+					qa_redirect('login', array('e' => $inemailhandle, 'ps' => '1'));
+				}
+				else
+				{
+					$errors['code'] = qa_lang('users/reset_code_wrong');						
+				}
+
+			}
+			else
+			{
+				$errors['emailhandle'] = qa_lang('users/user_not_found');					
+			}
+		}
+	}
+	else 
+	{
+		// in case the user clicked on the link in the email e and c are set in the URL
+		$inemailhandle = qa_get('e');
+		$incode = qa_get('c');
+		if(isset($inemailhandle) && isset($incode))
+		{
+			// we fill the form and submit by javascript
+			$dosubmitform = true;
+		}
+		else if(isset($inemailhandle) && !isset($incode))
+		{
+			// request comes directly from /forgot page, we only have the e in the URL
+			$showmsg_checkmail = true;
+		}
 	}
 
 
 //	Prepare content for theme
 
-	$qa_content=qa_content_prepare();
+	$qa_content = qa_content_prepare();
 
-	$qa_content['title']=qa_lang_html('users/reset_title');
-	$qa_content['error']=@$errors['page'];
+	$qa_content['title'] = qa_lang_html('users/reset_title');
+	
+	$qa_content['error'] = @$errors['page'];
 
 	if (empty($inemailhandle) || isset($errors['emailhandle']))
-		$forgotpath=qa_path('forgot');
+	{
+		$forgotpath = qa_path('forgot');			
+	}
 	else
-		$forgotpath=qa_path('forgot', array('e' => $inemailhandle));
+	{
+		$forgotpath = qa_path('forgot', array('e' => $inemailhandle));			
+	}
 
-	$qa_content['form']=array(
-		'tags' => 'method="post" action="'.qa_self_html().'"',
+	// only show message to check for email
+	if($showmsg_checkmail)
+	{
+		// $qa_content['success'] = qa_lang_html('users/reset_code_emailed');
+		$qa_content['error'] = qa_lang_html('users/reset_code_emailed');
+	}
+	else
+	{
+		$qa_content['form'] = array(
+			'tags' => 'method="post" action="'.qa_self_html().'" name="resetform"',
 
-		'style' => 'tall',
+			'style' => 'tall',
 
-		'ok' => empty($incode) ? qa_lang_html('users/reset_code_emailed') : null,
+			// 'ok' => empty($incode) ? qa_lang_html('users/reset_code_emailed') : null,
 
-		'fields' => array(
-			'email_handle' => array(
-				'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
-				'tags' => 'name="emailhandle" id="emailhandle"',
-				'value' => qa_html(@$inemailhandle),
-				'error' => qa_html(@$errors['emailhandle']),
+			'fields' => array(
+				'email_handle' => array(
+					'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
+					'tags' => 'name="emailhandle" id="emailhandle"',
+					'value' => qa_html(@$inemailhandle),
+					'error' => qa_html(@$errors['emailhandle']),
+				),
+
+				'code' => array(
+					'label' => qa_lang_html('users/reset_code_label'),
+					'tags' => 'name="code" id="code"',
+					'value' => qa_html(@$incode),
+					'error' => qa_html(@$errors['code']),
+					'note' => qa_lang_html('users/reset_code_emailed').' - '.
+						'<a href="'.qa_html($forgotpath).'">'.qa_lang_html('users/reset_code_another').'</a>',
+				),
 			),
 
-			'code' => array(
-				'label' => qa_lang_html('users/reset_code_label'),
-				'tags' => 'name="code" id="code"',
-				'value' => qa_html(@$incode),
-				'error' => qa_html(@$errors['code']),
-				'note' => qa_lang_html('users/reset_code_emailed').' - '.
-					'<a href="'.qa_html($forgotpath).'">'.qa_lang_html('users/reset_code_another').'</a>',
+			'buttons' => array(
+				'reset' => array(
+					'label' => qa_lang_html('users/send_password_button'),
+				),
 			),
-		),
 
-		'buttons' => array(
-			'reset' => array(
-				'label' => qa_lang_html('users/send_password_button'),
+			'hidden' => array(
+				'doreset' => '1',
+				'formcode' => qa_get_form_security_code('reset'),
 			),
-		),
+		);
 
-		'hidden' => array(
-			'doreset' => '1',
-			'formcode' => qa_get_form_security_code('reset'),
-		),
-	);
+		$qa_content['focusid'] = (isset($errors['emailhandle']) || !strlen(@$inemailhandle)) ? 'emailhandle' : 'code';
+	}
 
-	$qa_content['focusid']=(isset($errors['emailhandle']) || !strlen(@$inemailhandle)) ? 'emailhandle' : 'code';
-
-
+	if($dosubmitform)
+	{
+		$qa_content['custom'] = '
+			<script type="text/javascript">
+				document.resetform.submit();
+			</script>
+		';
+	}
+	
 	return $qa_content;
 
 


### PR DESCRIPTION
_Preamble: Did not know how I can prevent the other two commits from 2015..._

**NEW:**
1. Forgot password, enter username or email
2. Mail goes to user, front end shows: check your email
3. User clicks link in email, comes to reset page, data (code and email/handle) gets submitted by JS automatically
4. User gets the 2nd email that contains his new password, frontend shows: "password was sent to you", and the input fields, cursor in password field blinking
5. User checks his email, copies the password, done. 

Not perfect, but better than before!
