### PR TITLE
Remove unnecessary step in password reset

### DIFF
--- a/qa-include/lang/qa-lang-misc.php
+++ b/qa-include/lang/qa-lang-misc.php
@@ -76,6 +76,7 @@
 		'nav_user_pms' => 'Private messages',
 		'nav_user_qs' => 'All questions',
 		'nav_user_wall' => 'Wall',
+		'next_step' => 'Next step',
 		'no_activity_from_x' => 'No activity from ^',
 		'no_favorite_categories' => 'No favorite categories',
 		'no_favorite_qs' => 'No favorite questions',

--- a/qa-include/lang/qa-lang-users.php
+++ b/qa-include/lang/qa-lang-users.php
@@ -118,7 +118,6 @@
 		'save_profile' => 'Save Profile',
 		'save_user' => 'Save User',
 		'send_confirm_button' => 'Send Confirmation Link',
-		'send_password_button' => 'Send New Password',
 		'send_reset_button' => 'Send Reset Password Email',
 		'send_reset_note' => 'A message will be sent to your email address with instructions.',
 		'special_users' => 'Special users',

--- a/qa-include/pages/forgot.php
+++ b/qa-include/pages/forgot.php
@@ -54,13 +54,12 @@ if (qa_clicked('doforgot')) {
 		if (strpos($inemailhandle, '@') === false) { // handles can't contain @ symbols
 			$matchusers = qa_db_user_find_by_handle($inemailhandle);
 			$passemailhandle = !qa_opt('allow_login_email_only');
-
 		} else {
 			$matchusers = qa_db_user_find_by_email($inemailhandle);
 			$passemailhandle = true;
 		}
 
-		if (count($matchusers) != 1) // if we get more than one match (should be impossible) also give an error
+		if (count($matchusers) != 1 || !$passemailhandle) // if we get more than one match (should be impossible) also give an error
 			$errors['emailhandle'] = qa_lang('users/user_not_found');
 
 		if (qa_opt('captcha_on_reset_password'))
@@ -69,7 +68,7 @@ if (qa_clicked('doforgot')) {
 		if (empty($errors)) {
 			$inuserid = $matchusers[0];
 			qa_start_reset_user($inuserid);
-			qa_redirect('reset', $passemailhandle ? array('e' => $inemailhandle) : null); // redirect to page where code is entered
+			qa_redirect('reset', $passemailhandle ? array('e' => $inemailhandle, 's' => '1') : null); // redirect to page where code is entered
 		}
 	}
 
@@ -91,7 +90,7 @@ $qa_content['form'] = array(
 
 	'fields' => array(
 		'email_handle' => array(
-			'label' => qa_lang_html('users/email_handle_label'),
+			'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
 			'tags' => 'name="emailhandle" id="emailhandle"',
 			'value' => qa_html(@$inemailhandle),
 			'error' => qa_html(@$errors['emailhandle']),

--- a/qa-include/pages/reset.php
+++ b/qa-include/pages/reset.php
@@ -25,58 +25,145 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
-
 //	Check we're not using single-sign on integration and that we're not logged in
 
-if (QA_FINAL_EXTERNAL_USERS)
+if (QA_FINAL_EXTERNAL_USERS) {
 	qa_fatal_error('User login is handled by external code');
+}
 
-if (qa_is_logged_in())
+if (qa_is_logged_in()) {
 	qa_redirect('');
+}
 
+// Fetch the email or handle from POST or GET
+$emailHandle = qa_post_text('emailhandle');
+if (!isset($emailHandle)) {
+	$emailHandle = qa_get('e');
+}
+$emailHandle = trim($emailHandle); // if $emailHandle is null, trim returns an empty string
 
-//	Process incoming form
+// Fetch the code from POST or GET
+$code = qa_post_text('code');
+if (!isset($code)) {
+	$code = qa_get('c');
+}
+$code = trim($code); // if $code is null, trim returns an empty string
 
-if (qa_clicked('doreset')) {
+$forgotPath = strlen($emailHandle) > 0 ? qa_path('forgot', array('e' => $emailHandle)) : qa_path('forgot');
+
+$focusId = 'code';
+
+$errors = array();
+$fields = array(
+	'email_handle' => array(
+		'type' => 'static',
+		'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
+		'value' => qa_html($emailHandle),
+	),
+	'code' => array(
+		'label' => qa_lang_html('users/reset_code_label'),
+		'tags' => 'name="code" id="code"',
+		'value' => isset($code) ? qa_html($code) : null,
+		'note_force' => true,
+		'note' => qa_lang_html('users/reset_code_emailed') . ' - ' .
+			'<a href="' . qa_html($forgotPath) . '">' . qa_lang_html('users/reset_code_another') . '</a>',
+	),
+);
+$buttons = array(
+	'next' => array(
+		'tags' => 'name="donext"',
+		'label' => qa_lang_html('misc/next_step'),
+	),
+);
+$hidden = array(
+	'formcode' => qa_get_form_security_code('reset'),
+);
+
+if (strlen($emailHandle) > 0) {
 	require_once QA_INCLUDE_DIR . 'app/users-edit.php';
 	require_once QA_INCLUDE_DIR . 'db/users.php';
 
-	$inemailhandle = qa_post_text('emailhandle');
-	$incode = trim(qa_post_text('code')); // trim to prevent passing in blank values to match uninitiated DB rows
+	$hidden['emailhandle'] = $emailHandle;
 
-	$errors = array();
+	$matchingUsers = qa_opt('allow_login_email_only') || strpos($emailHandle, '@') !== false // handles can't contain @ symbols
+		? qa_db_user_find_by_email($emailHandle)
+		: qa_db_user_find_by_handle($emailHandle);
 
-	if (!qa_check_form_security_code('reset', qa_post_text('formcode')))
-		$errors['page'] = qa_lang_html('misc/form_security_again');
+	// Make sure there is only one match
+	if (count($matchingUsers) == 1) {
+		require_once QA_INCLUDE_DIR . 'db/selects.php';
 
-	else {
-		if (qa_opt('allow_login_email_only') || (strpos($inemailhandle, '@') !== false)) // handles can't contain @ symbols
-			$matchusers = qa_db_user_find_by_email($inemailhandle);
-		else
-			$matchusers = qa_db_user_find_by_handle($inemailhandle);
+		$userId = $matchingUsers[0];
+		$userInfo = qa_db_select_with_pending(qa_db_user_account_selectspec($userId, true));
 
-		if (count($matchusers) == 1) { // if match more than one (should be impossible), consider it a non-match
-			require_once QA_INCLUDE_DIR . 'db/selects.php';
+		// strlen() check is vital otherwise we can reset code for most users by entering the empty string
+		if (strlen($code) > 0) {
+			if (strtolower(trim($userInfo['emailcode'])) == strtolower($code)) {
+				// User input a valid code so no need to ask for it but pass it to the next step
+				unset($fields['code']);
+				$hidden['code'] = $code;
 
-			$inuserid = $matchusers[0];
-			$userinfo = qa_db_select_with_pending(qa_db_user_account_selectspec($inuserid, true));
+				$buttons = array(
+					'change' => array(
+						'tags' => 'name="dochangepassword"',
+						'label' => qa_lang_html('users/change_password'),
+					),
+				);
 
-			// strlen() check is vital otherwise we can reset code for most users by entering the empty string
-			if (strlen($incode) && strtolower(trim($userinfo['emailcode'])) == strtolower($incode)) {
-				qa_complete_reset_user($inuserid);
-				qa_redirect('login', array('e' => $inemailhandle, 'ps' => '1')); // redirect to login page
+				$focusId = 'newpassword1';
+
+				if (qa_clicked('dochangepassword')) {
+					$newPassword = qa_post_text('newpassword1');
+					$repeatPassword = qa_post_text('newpassword2');
+
+					if (!qa_check_form_security_code('reset', qa_post_text('formcode'))) {
+						$errors['page'] = qa_lang_html('misc/form_security_again');
+					} else {
+						$passwordError = qa_password_validate($newPassword, $userInfo);
+						if (!empty($passwordError)) {
+							$errors['new_1'] = $passwordError['password'];
+						}
+
+						if ($newPassword != $repeatPassword) {
+							$errors['new_2'] = qa_lang('users/password_mismatch');
+						}
+
+						if (empty($errors)) {
+							// Update password, login user, fire events and redirect to home page
+							qa_finish_reset_user($userId, $newPassword);
+							qa_redirect('');
+						}
+					}
+				}
+
+				$fields['new_1'] = array(
+					'label' => qa_lang_html('users/new_password_1'),
+					'tags' => 'name="newpassword1" id="newpassword1"',
+					'type' => 'password',
+					'error' => qa_html(isset($errors['new_1']) ? $errors['new_1'] : null),
+				);
+
+				$fields['new_2'] = array(
+					'label' => qa_lang_html('users/new_password_2'),
+					'tags' => 'name="newpassword2"',
+					'type' => 'password',
+					'error' => qa_html(isset($errors['new_2']) ? $errors['new_2'] : null),
+				);
 			} else {
-				$errors['code'] = qa_lang('users/reset_code_wrong');
+				// User input wrong code so show field with error
+				$fields['code']['error'] = qa_lang('users/reset_code_wrong');
 			}
-
-		} else {
-			$errors['emailhandle'] = qa_lang('users/user_not_found');
+		} else if (qa_clicked('donext')) {
+			// If user submitted the form with an empty code
+			$fields['code']['error'] = qa_lang('users/reset_code_wrong');
 		}
+	} else {
+		// If match more than one (should be impossible), consider it a non-match
+		$errors['page'] = qa_lang_html('users/user_not_found');
 	}
-
 } else {
-	$inemailhandle = qa_get('e');
-	$incode = qa_get('c');
+	// If there is no handle notify the user
+	$errors['page'] = qa_lang_html('users/user_not_found');
 }
 
 
@@ -85,51 +172,25 @@ if (qa_clicked('doreset')) {
 $qa_content = qa_content_prepare();
 
 $qa_content['title'] = qa_lang_html('users/reset_title');
-$qa_content['error'] = @$errors['page'];
+$qa_content['error'] = isset($errors['page']) ? $errors['page'] : null;
 
-if (empty($inemailhandle) || isset($errors['emailhandle']))
-	$forgotpath = qa_path('forgot');
-else
-	$forgotpath = qa_path('forgot', array('e' => $inemailhandle));
+if (!isset($errors['page'])) {
+	// Using this form action instead of qa_self_html() to get rid of the 's' (success) GET parameter from forgot.php
+	$qa_content['form'] = array(
+		'tags' => 'method="post" action="' . qa_path('reset') . '"',
 
-$qa_content['form'] = array(
-	'tags' => 'method="post" action="' . qa_self_html() . '"',
+		'style' => 'tall',
 
-	'style' => 'tall',
+		'ok' => qa_get('s') ? qa_lang_html('users/reset_code_emailed') : null,
 
-	'ok' => empty($incode) ? qa_lang_html('users/reset_code_emailed') : null,
+		'fields' => $fields,
 
-	'fields' => array(
-		'email_handle' => array(
-			'label' => qa_opt('allow_login_email_only') ? qa_lang_html('users/email_label') : qa_lang_html('users/email_handle_label'),
-			'tags' => 'name="emailhandle" id="emailhandle"',
-			'value' => qa_html(@$inemailhandle),
-			'error' => qa_html(@$errors['emailhandle']),
-		),
+		'buttons' => $buttons,
 
-		'code' => array(
-			'label' => qa_lang_html('users/reset_code_label'),
-			'tags' => 'name="code" id="code"',
-			'value' => qa_html(@$incode),
-			'error' => qa_html(@$errors['code']),
-			'note' => qa_lang_html('users/reset_code_emailed') . ' - ' .
-				'<a href="' . qa_html($forgotpath) . '">' . qa_lang_html('users/reset_code_another') . '</a>',
-		),
-	),
+		'hidden' => $hidden,
+	);
+}
 
-	'buttons' => array(
-		'reset' => array(
-			'label' => qa_lang_html('users/send_password_button'),
-		),
-	),
-
-	'hidden' => array(
-		'doreset' => '1',
-		'formcode' => qa_get_form_security_code('reset'),
-	),
-);
-
-$qa_content['focusid'] = (isset($errors['emailhandle']) || !strlen(@$inemailhandle)) ? 'emailhandle' : 'code';
-
+$qa_content['focusid'] = $focusId;
 
 return $qa_content;


### PR DESCRIPTION
I took some of the suggestions in #455 and tried to make the forgot password process a bit shorter. In this branch, the user should navigate to `/forgot` and input their username as they did before:

![1](https://cloud.githubusercontent.com/assets/1449790/19617454/26380330-9807-11e6-8ce9-aecc8dc3e30c.png)

This will do 2 things: one would be to send the same first email as before (with a link to the reset password page containing the code and the shortcut link). The other would be to display a form to input only the code:

![2](https://cloud.githubusercontent.com/assets/1449790/19617466/b28e0c6c-9807-11e6-99bf-6e3bd9bfe50e.png)

If the user inputs the code manually and clicks on the _Next step_ button, this will take them to the password confirmation page (which is still in the reset.php file)

![3](https://cloud.githubusercontent.com/assets/1449790/19617486/46539da4-9808-11e6-867b-fafe1948657f.png)

If the user instead of manually writing the code, prefers to click the link in the email, then he will be sent to the password confirmation page directly.

Once the user inputs a valid password they will get automatically logged in. Alternative, the user could be sent to the login section, but this seems to be unnecessary, IMO.

In the previous process it was possible to reset the password from `/forgot` and from `/reset`. Now it is no longer possible to reset from `/reset` as the username is input in `/forgot`
