### PR TITLE
Fix a_unselect not being called when hiding selected answer

### DIFF
--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -127,7 +127,7 @@
 	function qa_question_set_selchildid($userid, $handle, $cookieid, $oldquestion, $selchildid, $answers)
 /*
 	Set the selected answer (application level) of $oldquestion to $selchildid. Pass details of the user doing this
-	in $userid, $handle and $cookieid, and the database records for all answers to the question in $answers.
+	in $userid, $handle and $cookieid, and the database records for the selected and deselected answers in $answers.
 	Handles user points values and notifications.
 	See qa-app-posts.php for a higher-level function which is easier to use.
 */
@@ -620,7 +620,7 @@
 			}
 
 			if ($question['selchildid'] == $oldanswer['postid']) { // remove selected answer
-				qa_question_set_selchildid(null, null, null, $question, null, $answers);
+				qa_question_set_selchildid(null, null, null, $question, null, array($oldanswer['postid'] => $oldanswer));
 			}
 
 		} elseif ($status==QA_POST_STATUS_NORMAL) {

--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -877,7 +877,7 @@
 			qa_post_index($oldanswer['postid'], 'C', $question['postid'], $parentid, null, $content, $format, $text, null, $oldanswer['categoryid']);
 
 		if ($question['selchildid'] == $oldanswer['postid']) { // remove selected answer
-			qa_question_set_selchildid(null, null, null, $question, null, $answers);
+			qa_question_set_selchildid(null, null, null, $question, null, array($oldanswer['postid'] => $oldanswer));
 		}
 
 		$eventparams=array(


### PR DESCRIPTION
I slightly change the documentation of `qa_question_set_selchildid` as it doesn't actually need all answers but just the affected ones at most.

Commit to blame: @8c4db57c71383cf679f0992311430843b4dff764

PS: I've just realized now single-line control structures require braces. Yay!
