### PR TITLE
Do not log security form violations unless in debug mode

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -1189,7 +1189,7 @@ in a category for which they have elevated privileges).
 				$reportproblems[]='code '.$value.' malformed';
 		}
 
-		if (count($reportproblems))
+		if (!empty($reportproblems) && QA_DEBUG_PERFORMANCE)
 			@error_log(
 				'PHP Question2Answer form security violation for '.$action.
 				' by '.(qa_is_logged_in() ? ('userid '.qa_get_logged_in_userid()) : 'anonymous').


### PR DESCRIPTION
There are many bots around and they generate a lot of information in the error log making it hard to browse. Besides, that information are not errors per se, but just the result of publishing a site in Internet. Maybe displaying them when in debug mode is a good option. Additionally, that could be set from an admin option, but most people won't understand what that is nor how to interpret the logs either. It might only be necessary in "development mode" which we don't have but debug performance is close enough :)
