### PR TITLE
Fetch latest released Q2A version from GitHub itself

### DIFF
--- a/qa-content/qa-admin.js
+++ b/qa-content/qa-admin.js
@@ -134,9 +134,9 @@ function qa_admin_click(target)
 	return false;
 }
 
-function qa_version_check(uri, version, elem)
+function qa_version_check(uri, version, elem, isCore)
 {
-	var params={uri:uri, version:version};
+	var params={uri:uri, version:version, isCore:isCore};
 
 	qa_ajax_post('version', params,
 		function (lines) {

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -1075,7 +1075,7 @@ foreach ($showoptions as $optionname) {
 					$updatehtml = '(<span id="' . $elementid . '">...</span>)';
 
 					$qa_content['script_onloads'][] = array(
-						"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ");"
+						"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ", false);"
 					);
 
 				}

--- a/qa-include/pages/admin/admin-plugins.php
+++ b/qa-include/pages/admin/admin-plugins.php
@@ -153,7 +153,7 @@ if (!empty($pluginfiles)) {
 			$updatehtml = '(<span id="' . $elementid . '">...</span>)';
 
 			$qa_content['script_onloads'][] = array(
-				"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ");"
+				"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ", false);"
 			);
 
 		} else

--- a/qa-include/pages/admin/admin-stats.php
+++ b/qa-include/pages/admin/admin-stats.php
@@ -74,8 +74,7 @@ $qa_content['form'] = array(
 		'q2a_latest' => array(
 			'label' => qa_lang_html('admin/q2a_latest_version'),
 			'type' => 'custom',
-			'html' => '<iframe src="http://www.question2answer.org/question2answer-latest.php?version=' . urlencode(QA_VERSION) . '&language=' . urlencode(qa_opt('site_language')) .
-				'" width="100" height="16" style="vertical-align:middle; border:0; background:transparent;" allowTransparency="true" scrolling="no" frameborder="0"></iframe>',
+			'html' => '<span id="q2a-version">...</span>',
 		),
 
 		'break0' => array(
@@ -273,6 +272,10 @@ if (defined('QA_BLOBS_DIRECTORY')) {
 
 $qa_content['script_rel'][] = 'qa-content/qa-admin.js?' . QA_VERSION;
 $qa_content['script_var']['qa_warning_recalc'] = qa_lang('admin/stop_recalc_warning');
+
+$qa_content['script_onloads'][] = array(
+    "qa_version_check('https://raw.githubusercontent.com/q2a/question2answer/master/VERSION.txt', " . qa_js(qa_html(QA_VERSION), true) . ", 'q2a-version', true);"
+);
 
 $qa_content['navigation']['sub'] = qa_admin_sub_navigation();
 


### PR DESCRIPTION
I know this might be a kind of political commit but it:

- Improves the look and feel of the number as the links are now rendered by the theme and not in an iframe
- Follows the `all development is taking place through GitHub` premise in the README
- Saves time when releasing a new Q2A version
- Decouples the need of getting both links updated before releasing which means more independance
- Slightly increases privacy :)