### PR TITLE
Fix words falling off the edge of the answer container

### DIFF
--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -912,7 +912,7 @@ blockquote p {
 .qa-q-view-content,
 .qa-a-item-content,
 .qa-c-item-content {
-	word-break: break-word;
+	word-wrap: break-word;
 }
 
 .qa-q-view-content table, .qa-a-item-content table, .qa-c-item-content table {


### PR DESCRIPTION
![screen shot 2016-10-19 at 9 19 09 am](https://cloud.githubusercontent.com/assets/1449790/20045883/5bffd582-a483-11e6-9f01-fd5cadf4fcda.png)

It only applies to Firefox. It seems `word-break` is not standard.

Related to: http://www.question2answer.org/qa/54257?show=54631#c54631