### PR TITLE
Include confirmation code in confirmation email

### DIFF
--- a/qa-include/app/users-edit.php
+++ b/qa-include/app/users-edit.php
@@ -250,23 +250,29 @@
 
 		$userinfo=qa_db_select_with_pending(qa_db_user_account_selectspec($userid, true));
 
+		$emailcode = qa_db_user_rand_emailcode();
+
 		if (!qa_send_notification($userid, $userinfo['email'], $userinfo['handle'], qa_lang('emails/confirm_subject'), qa_lang('emails/confirm_body'), array(
-			'^url' => qa_get_new_confirm_url($userid, $userinfo['handle']),
+			'^url' => qa_get_new_confirm_url($userid, $userinfo['handle'], $emailcode),
+			'^code' => $emailcode,
 		)))
 			qa_fatal_error('Could not send email confirmation');
 	}
 
 
-	function qa_get_new_confirm_url($userid, $handle)
+	function qa_get_new_confirm_url($userid, $handle, $emailcode = null)
 /*
-	Set a new email confirmation code for the user and return the corresponding link
+	Set a new email confirmation code for the user and return the corresponding link. If the email code is also sent then that value
+	is used. Otherwise, a new email code is generated
 */
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		require_once QA_INCLUDE_DIR.'db/users.php';
 
-		$emailcode=qa_db_user_rand_emailcode();
+		if (!isset($emailcode)) {
+			$emailcode = qa_db_user_rand_emailcode();
+		}
 		qa_db_user_set($userid, 'emailcode', $emailcode);
 
 		return qa_path_absolute('confirm', array('c' => $emailcode, 'u' => $handle));

--- a/qa-include/lang/qa-lang-emails.php
+++ b/qa-include/lang/qa-lang-emails.php
@@ -33,7 +33,7 @@
 		'c_commented_body' => "A new comment by ^c_handle has been added after your comment on ^site_title:\n\n^open^c_content^close\n\nThe discussion is following:\n\n^open^c_context^close\n\nYou may respond by adding another comment:\n\n^url\n\nThank you,\n\n^site_title",
 		'c_commented_subject' => 'Your ^site_title comment has been added to',
 
-		'confirm_body' => "Please click below to confirm your email address for ^site_title.\n\n^url\n\nThank you,\n^site_title",
+		'confirm_body' => "Please click below to confirm your email address for ^site_title.\n\n^url\n\nConfirmation code: ^code\n\n Thank you,\n^site_title",
 		'confirm_subject' => '^site_title - Email Address Confirmation',
 
 		'feedback_body' => "Comments:\n^message\n\nName:\n^name\n\nEmail:\n^email\n\nPrevious page:\n^previous\n\nUser:\n^url\n\nIP address:\n^ip\n\nBrowser:\n^browser",


### PR DESCRIPTION
Just another awkward commit.

Imagine a user is using a Q2A mobile app. They request to change their e-mail address and the site requires e-mail confirmation. They open their mobile e-mail client. Tthe email they receive has a link which makes them open a 3rd app: the browser. The idea of the mobile app is not to depend on the browser but unless the user selectively copies the code from the URL they have no other option than opening the browser.

This way there is no dependency on the browser and it would be possible for the mobile app to ask the user to input the code manually, which can be easily copy/pasted.