### PR TITLE
Fix overrides not being called after enabling/disabling plugins PR merge

### DIFF
--- a/qa-include/qa-ajax.php
+++ b/qa-include/qa-ajax.php
@@ -20,30 +20,6 @@
 	More about this license: http://www.question2answer.org/license.php
 */
 
-// Output this header as early as possible
-
-header('Content-Type: text/plain; charset=utf-8');
-
-
-// Ensure no PHP errors are shown in the Ajax response
-
-@ini_set('display_errors', 0);
-
-
-// Load the Q2A base file which sets up a bunch of crucial functions
-
-require 'qa-base.php';
-
-qa_report_process_stage('init_ajax');
-
-
-// Get general Ajax parameters from the POST payload, and clear $_GET
-
-qa_set_request(qa_post_text('qa_request'), qa_post_text('qa_root'));
-
-$_GET = array(); // for qa_self_html()
-
-
 // Database failure handler
 
 function qa_ajax_db_fail_handler()
@@ -52,6 +28,29 @@ function qa_ajax_db_fail_handler()
 	qa_exit('error');
 }
 
+// Ensure no PHP errors are shown in the Ajax response
+
+@ini_set('display_errors', 0);
+
+// Output this header as early as possible
+
+header('Content-Type: text/plain; charset=utf-8');
+
+// Load the Q2A base file which sets up a bunch of crucial functions
+
+require 'qa-base.php';
+
+qa_db_set_fail_handler('qa_ajax_db_fail_handler');
+
+qa_initialize();
+
+qa_report_process_stage('init_ajax');
+
+// Get general Ajax parameters from the POST payload, and clear $_GET
+
+qa_set_request(qa_post_text('qa_request'), qa_post_text('qa_root'));
+
+$_GET = array(); // for qa_self_html()
 
 // Perform the appropriate Ajax operation
 
@@ -78,10 +77,8 @@ $routing = array(
 $operation = qa_post_text('qa_operation');
 
 if (isset($routing[$operation])) {
-	qa_db_connect('qa_ajax_db_fail_handler');
-
 	qa_initialize_buffering();
 	require QA_INCLUDE_DIR . 'ajax/' . $routing[$operation];
-
-	qa_db_disconnect();
 }
+
+qa_db_disconnect();

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -62,14 +62,11 @@
 	qa_initialize_constants_2();
 	qa_initialize_modularity();
 	qa_register_core_modules();
-	qa_load_override_files();
 
 	require_once QA_INCLUDE_DIR.'qa-db.php';
 
-	qa_db_allow_connect();
-
 	qa_load_plugin_files();
-
+	qa_load_override_files();
 
 
 //	Version comparison functions

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -65,9 +65,12 @@
 
 	require_once QA_INCLUDE_DIR.'qa-db.php';
 
-	qa_load_plugin_files();
-	qa_load_override_files();
+	function qa_initialize() {
+		qa_db_connect();
 
+		qa_load_plugin_files();
+		qa_load_override_files();
+	}
 
 //	Version comparison functions
 

--- a/qa-include/qa-blob.php
+++ b/qa-include/qa-blob.php
@@ -20,10 +20,7 @@
 	More about this license: http://www.question2answer.org/license.php
 */
 
-
-// Ensure no PHP errors are shown in the blob response
-
-@ini_set('display_errors', 0);
+// Database failure handler
 
 function qa_blob_db_fail_handler()
 {
@@ -31,19 +28,23 @@ function qa_blob_db_fail_handler()
 	qa_exit('error');
 }
 
+// Ensure no PHP errors are shown in the blob response
+
+@ini_set('display_errors', 0);
 
 // Load the Q2A base file which sets up a bunch of crucial stuff
 
 require 'qa-base.php';
 
-qa_report_process_stage('init_blob');
+qa_db_set_fail_handler('qa_blob_db_fail_handler');
 
+qa_initialize();
+
+qa_report_process_stage('init_blob');
 
 // Output the blob in question
 
 require_once QA_INCLUDE_DIR.'app/blobs.php';
-
-qa_db_connect('qa_blob_db_fail_handler');
 
 $blob = qa_read_blob(qa_get('qa_blobid'));
 

--- a/qa-include/qa-check-lang.php
+++ b/qa-include/qa-check-lang.php
@@ -23,6 +23,9 @@
 	define('QA_BASE_DIR', dirname(dirname(empty($_SERVER['SCRIPT_FILENAME']) ? __FILE__ : $_SERVER['SCRIPT_FILENAME'])).'/');
 
 	require 'qa-base.php';
+
+	qa_initialize();
+
 	require_once QA_INCLUDE_DIR.'app/users.php';
 
 	if (qa_get_logged_in_level() < QA_USER_LEVEL_ADMIN)

--- a/qa-include/qa-db.php
+++ b/qa-include/qa-db.php
@@ -27,20 +27,6 @@
 
 
 	/**
-	 * Indicates to the Q2A database layer that database connections are permitted fro this point forwards
-	 * (before this point, some plugins may not have had a chance to override some database access functions).
-	 */
-	function qa_db_allow_connect()
-	{
-		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
-
-		global $qa_db_allow_connect;
-
-		$qa_db_allow_connect=true;
-	}
-
-
-	/**
 	 * Connect to the Q2A database, select the right database, optionally install the $failhandler (and call it if necessary).
 	 * Uses mysqli as of Q2A 1.7.
 	 */
@@ -48,10 +34,7 @@
 	{
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-		global $qa_db_connection, $qa_db_fail_handler, $qa_db_allow_connect;
-
-		if (!$qa_db_allow_connect)
-			qa_fatal_error('It appears that a plugin is trying to access the database, but this is not allowed until Q2A initialization is complete.');
+		global $qa_db_connection, $qa_db_fail_handler;
 
 		if (isset($failhandler))
 			$qa_db_fail_handler = $failhandler; // set this even if connection already opened

--- a/qa-include/qa-db.php
+++ b/qa-include/qa-db.php
@@ -25,6 +25,19 @@
 		exit;
 	}
 
+	/**
+	* Set the database fail handler. No matter if the connection is already opened.
+	*
+	* @param callable $failhandler
+	*/
+	function qa_db_set_fail_handler($failhandler)
+	{
+		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
+
+		global $qa_db_fail_handler;
+
+		$qa_db_fail_handler = $failhandler;
+	}
 
 	/**
 	 * Connect to the Q2A database, select the right database, optionally install the $failhandler (and call it if necessary).
@@ -37,7 +50,7 @@
 		global $qa_db_connection, $qa_db_fail_handler;
 
 		if (isset($failhandler))
-			$qa_db_fail_handler = $failhandler; // set this even if connection already opened
+			qa_db_set_fail_handler($failhandler);
 
 		if ($qa_db_connection instanceof mysqli)
 			return;

--- a/qa-include/qa-feed.php
+++ b/qa-include/qa-feed.php
@@ -27,8 +27,6 @@
 
 	@ini_set('display_errors', 0); // we don't want to show PHP errors to RSS readers
 
-	qa_report_process_stage('init_feed');
-
 	require_once QA_INCLUDE_DIR.'app/options.php';
 
 
@@ -91,7 +89,12 @@
 
 //	Connect to database and get the type of feed and category requested (in some cases these are overridden later)
 
-	qa_db_connect('qa_feed_db_fail_handler');
+	qa_db_set_fail_handler('qa_feed_db_fail_handler');
+
+	qa_initialize();
+
+	qa_report_process_stage('init_feed');
+
 	qa_preload_options();
 
 	$requestlower=strtolower(qa_request());

--- a/qa-include/qa-image.php
+++ b/qa-include/qa-image.php
@@ -20,10 +20,7 @@
 	More about this license: http://www.question2answer.org/license.php
 */
 
-
-//	Ensure no PHP errors are shown in the image data
-
-	@ini_set('display_errors', 0);
+//  Database failure handler
 
 	function qa_image_db_fail_handler()
 	{
@@ -31,19 +28,23 @@
 		qa_exit('error');
 	}
 
+//	Ensure no PHP errors are shown in the image data
+
+	@ini_set('display_errors', 0);
 
 //	Load the Q2A base file which sets up a bunch of crucial stuff
 
 	require 'qa-base.php';
 
-	qa_report_process_stage('init_image');
-
-
 //	Retrieve the scaled image from the cache if available
 
-	require_once QA_INCLUDE_DIR.'db/cache.php';
+	qa_db_set_fail_handler('qa_image_db_fail_handler');
 
-	qa_db_connect('qa_image_db_fail_handler');
+	qa_initialize();
+
+	qa_report_process_stage('init_image');
+
+	require_once QA_INCLUDE_DIR.'db/cache.php';
 
 	$blobid=qa_get('qa_blobid');
 	$size=(int)qa_get('qa_size');

--- a/qa-include/qa-install.php
+++ b/qa-include/qa-install.php
@@ -27,9 +27,6 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 
 require_once QA_INCLUDE_DIR.'db/install.php';
 
-qa_report_process_stage('init_install');
-
-
 // Define database failure handler for install process, if not defined already (file could be included more than once)
 
 if (!function_exists('qa_install_db_fail_handler')) {
@@ -60,7 +57,6 @@ $buttons = array();
 $fields = array();
 $fielderrors = array();
 $hidden = array();
-
 
 // Process user handling higher up to avoid 'headers already sent' warning
 
@@ -184,6 +180,8 @@ else {
 	}
 
 	if (qa_clicked('module')) {
+		qa_initialize();
+
 		$moduletype = qa_post_text('moduletype');
 		$modulename = qa_post_text('modulename');
 
@@ -273,6 +271,8 @@ if (qa_db_connection(false) !== null && !@$pass_failure_from_install) {
 			}
 			else {
 				$tables = qa_db_list_tables();
+
+				qa_initialize();
 
 				$moduletypes = qa_list_module_types();
 

--- a/qa-include/qa-page.php
+++ b/qa-include/qa-page.php
@@ -815,8 +815,11 @@
 
 	global $qa_usage;
 
+	qa_db_set_fail_handler('qa_page_db_fail_handler');
+
+	qa_initialize();
+
 	qa_report_process_stage('init_page');
-	qa_db_connect('qa_page_db_fail_handler');
 
 	qa_page_queue_pending();
 	qa_load_state();

--- a/qa-tests/autoload.php
+++ b/qa-tests/autoload.php
@@ -1,3 +1,5 @@
 <?php
 // currently, all Q2A code depends on qa-base
 require_once __DIR__.'/../qa-include/qa-base.php';
+
+qa_initialize();


### PR DESCRIPTION
My previous pull request about disabling plugins generated an issue. See the previous PR diff:
```diff
        qa_initialize_constants_2();
        qa_initialize_modularity();
        qa_register_core_modules();
-       qa_load_plugin_files();
        qa_load_override_files();
 
        require_once QA_INCLUDE_DIR.'qa-db.php';
 
        qa_db_allow_connect();
 
+       qa_load_plugin_files();
```


Plugin overrides get loaded from plugin files. So if we try to load them before the plugin files are loaded then the overrides will be empty. So they need to move that line after the `qa_load_plugin_files();`.

However, there is a silly issue. What about the `qa_db_allow_connect()` function? It seems it is a barrier to make sure nothing accesses the database before that point. The thing is, it can be overridden. So loading the overrides AFTER running that function will result in no effect from that specific override override. Making the `qa_db_allow_connect()` function not overrideable makes it almost useless.

Furthermore, the `qa_db_allow_connect()` doesn't actually provide any kind of additional security, as far as I see, because the plugins could still connect to the database without using the Q2A DB functions (they have access to the connection user/pass/host).

My suggestions/comments are:

 * Accept the fact the core needs to access the database before loading the plugin files
 * Remove the `qa_db_allow_connect()` function as there is no real benefit from it
 * To workaround the missing function it is still possible to override the `qa_db_connect()`
 * I hardly believe someone out there has actually overridden `qa_db_allow_connect()` (ever) so adding it to the changelog I guess it should be more than enough

**Edit: Another issue was found so also added the `Fix database fail handlers` commit**

Accessing the database before loading the plugin files really messed things up. Installation is not currently working. The DB fail handler that catches the errors and detects no table exist is not being assigned on time. I guess this should be enough to get you started.

Now, I found no simple and easy way to fix this without considerably rearranging code. This is what I did for this suggestion:

 * I split `qa-base.php` so that calling it doesn't force a database read (which was the change added when enabling/disabling plugins
 * `require 'qa-base.php';` should now always be followed by `qa_initialize()` in order to connect to the database and load plugin files
 * Had to slightly change the routing mechanism (nothing too deep)
 * Had to remove qa_report_process_stage('init_install')

Again, this is just a suggestion. I don't like it but I couldn't come with something that perform less radical changes to the core. I hope this at least servers to point at some parts of code that might need to be updated.point some parts of code.