### PR TITLE
Add ability to load plugins after and before connecting to the DB

### DIFF
--- a/qa-tests/autoload.php
+++ b/qa-tests/autoload.php
@@ -1,3 +1,9 @@
 <?php
 // currently, all Q2A code depends on qa-base
+
+global $qa_options_cache;
+
+// Needed in order to avoid accessing the database while including the qa-base.php file
+$qa_options_cache['enabled_plugins'] = '';
+
 require_once __DIR__.'/../qa-include/qa-base.php';


### PR DESCRIPTION
Summary of the changes
 * Split the `qa_load_plugin_files()` function into the parsing of the metadata files and the loading the plugins themselves
 * Moved the previous mentioned functions to the `PluginManager`
 * Modified how overrides are loaded: instead of being added to the global `$qa_override_files` variable they are queued in `$qa_override_files_temp` as a delayed load
 * Function `qa_load_override_files()` instead of loading all overrides from the global variable `$qa_override_files` it loads them from the temp one and also adds them to the original `$a_override_files` global variable just to keep backwards compatibility (probably unnecessary)
 * The plugin load (including loading the overrides) happen before and after connecting to the database
 * Added `load_order` to the `metadata.json` (it a string just to make sure we have more values to set than just a boolean in the future). Current values could be `after_db_init` and `before_db_init`.
 * Plugins that are loaded after the database is loaded can not be disabled
 * Default behavior for `metadata.json` files without `load_order` was set to load before. That way only plugins that specifically update their metadata for v1.8 will actually be able to be disabled. The opposite behavior could also be fine, however, it will bring issues to users that have overridden the core database functions