### PR TITLE
Resolve "A non-numeric value encountered" error on file format.php

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1102,7 +1102,7 @@
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		$thispage=1+floor($start/$pagesize);
-		$lastpage=ceil(min($count, 1+QA_MAX_LIMIT_START)/$pagesize);
+		$lastpage=ceil(min((int)$count, 1+QA_MAX_LIMIT_START)/$pagesize);
 
 		if (($thispage>1) || ($lastpage>$thispage)) {
 			$links=array('label' => qa_lang_html('main/page_label'), 'items' => array());


### PR DESCRIPTION
The error "A non-numeric value encountered" ocurrs when has no questions in database.
Solved with a explicit type convertion.