### PR TITLE
Fixed php 5.3 Travis CI fail issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 
 before_script:
   # PHP_CodeSniffer
-  - curl -L -o phpcs.phar https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+  - curl -L -o phpcs.phar https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.9.1/phpcs.phar
   # PHPUnit - manually download old version so that it works on PHP 7
   - curl -L -o phpunit.phar https://phar.phpunit.de/phpunit-4.8.35.phar
   # Basic config required for PHPUnit


### PR DESCRIPTION
Travis CI failing for Q2A v18, issue with php 5.3, see below link for more detail
http://question2answer.org/qa/58152/travis-ci-failing-for-q2a-v18-issue-with-php-5-3