### PR TITLE
Unify own post message language string

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -514,7 +514,7 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 
 		} elseif ($isbyuser) {
 			$fields['vote_state'] = 'disabled';
-			$fields['vote_up_tags'] = 'title="' . qa_lang_html($isanswer ? 'main/vote_disabled_my_a' : 'main/vote_disabled_my_q') . '"';
+			$fields['vote_up_tags'] = 'title="' . qa_lang_html('main/vote_disabled_my_post') . '"';
 			$fields['vote_down_tags'] = $fields['vote_up_tags'];
 
 		} elseif (strpos($voteview, '-disabled-')) {

--- a/qa-include/lang/qa-lang-main.php
+++ b/qa-include/lang/qa-lang-main.php
@@ -193,8 +193,9 @@ return array(
 	'vote_disabled_hidden_a' => 'You cannot vote on hidden answers',  // @deprecated
 	'vote_disabled_hidden_q' => 'You cannot vote on hidden questions',  // @deprecated
 	'vote_disabled_level' => 'Voting is only available to some users',
-	'vote_disabled_my_a' => 'You cannot vote on your own answers',
-	'vote_disabled_my_q' => 'You cannot vote on your own questions',
+	'vote_disabled_my_post' => 'You cannot vote on your own posts',
+	'vote_disabled_my_a' => 'You cannot vote on your own answers',  // @deprecated
+	'vote_disabled_my_q' => 'You cannot vote on your own questions',  // @deprecated
 	'vote_disabled_q_page_only' => 'Please view this question to vote',
 	'vote_disabled_queued' => 'You can only vote on approved posts',
 	'vote_down_must_confirm' => 'Please ^5confirm your email address^6 to vote down.',


### PR DESCRIPTION
Just passing by and saw the simple issue #536 so I thought of sending a keep-alive.

I suggest deprecating `vote_disabled_my_x the same` the same as `vote_disabled_hidden_x`.