### PR TITLE
Fix a few warnings generated by reading contents from non-existent files

### DIFF
--- a/qa-include/app/admin.php
+++ b/qa-include/app/admin.php
@@ -151,7 +151,7 @@ function qa_admin_theme_options()
 		$metadata = $metadataUtil->fetchFromAddonPath($directory);
 		if (empty($metadata)) {
 			// limit theme parsing to first 8kB
-			$contents = file_get_contents($directory . '/qa-styles.css', false, null, 0, 8192);
+			$contents = @file_get_contents($directory . '/qa-styles.css', false, null, 0, 8192);
 			$metadata = qa_addon_metadata($contents, 'Theme');
 		}
 		$options[$theme] = isset($metadata['name']) ? $metadata['name'] : $theme;

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -1042,7 +1042,7 @@ foreach ($showoptions as $optionname) {
 				$metadata = $metadataUtil->fetchFromAddonPath($themedirectory);
 				if (empty($metadata)) {
 					// limit theme parsing to first 8kB
-					$contents = file_get_contents($themedirectory . '/qa-styles.css', false, null, 0, 8192);
+					$contents = @file_get_contents($themedirectory . '/qa-styles.css', false, null, 0, 8192);
 					$metadata = qa_addon_metadata($contents, 'Theme');
 				}
 


### PR DESCRIPTION
At least happening in PHP 7. Applied the old-style fix because it is deprecated code.