### PR TITLE
Fix table counts during Q2A installation

### DIFF
--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -555,7 +555,7 @@ function qa_array_to_keys($array)
  */
 function qa_db_missing_tables($definitions)
 {
-	$keydbtables = qa_array_to_keys(qa_db_list_tables());
+	$keydbtables = qa_array_to_keys(qa_db_list_tables(true));
 
 	$missing = array();
 
@@ -776,7 +776,7 @@ function qa_db_upgrade_tables()
 
 	// Write-lock all Q2A tables before we start so no one can read or write anything
 
-	$keydbtables = qa_array_to_keys(qa_db_list_tables());
+	$keydbtables = qa_array_to_keys(qa_db_list_tables(true));
 
 	foreach ($definitions as $rawname => $definition)
 		if (isset($keydbtables[qa_db_add_table_prefix($rawname)]))

--- a/qa-include/qa-db.php
+++ b/qa-include/qa-db.php
@@ -448,10 +448,19 @@ function qa_db_list_tables_lc()
 
 /**
  * Return an array of the names of all tables in the Q2A database.
+ *
+ * @param bool $onlyTablesWithPrefix Determine if the result should only include tables with the
+ * QA_MYSQL_TABLE_PREFIX or if it should include all tables in the database.
  */
-function qa_db_list_tables()
+function qa_db_list_tables($onlyTablesWithPrefix = false)
 {
-	return qa_db_read_all_values(qa_db_query_raw('SHOW TABLES'));
+	$query = 'SHOW TABLES';
+
+	if ($onlyTablesWithPrefix) {
+		$query .= ' LIKE "' . QA_MYSQL_TABLE_PREFIX . '%"';
+	}
+
+	return qa_db_read_all_values(qa_db_query_raw($query));
 }
 
 


### PR DESCRIPTION
To reproduce this create a new schema. Add a custom table. Start installing Q2A. You'll eventually see:
![image](https://user-images.githubusercontent.com/1449790/31048830-4c484766-a5fc-11e7-939c-f6c8d7d6bf63.png)

The fix just filters based on the Q2A table prefix. It also takes that into account when upgrading as it doesn't make any sense to block non-Q2A tables while doing so.

Note plugins should still receive the full table list (not the filtered one). Otherwise, this won't be backwards compatible.

This makes me wonder whether plugins should use or not the Q2A table prefix in their table names. I used to think they shouldn't in order to avoid "namespaces" issues with the core. However, other issues might still arise if there are 2 sites sharing the same schema using different prefix that have the same plugin installed. That plugin would try to create the same table twice.

I'm even thinking plugins should have specific sub-prefix for table names so that the table names look like this `qa_plugin_*`. So the core will know it can't use that prefix for a table name nor take them into account when counting them. Not for 1.8 I guess :)