### PR TITLE
Fix non-ANSI group-by queries

### DIFF
--- a/qa-include/db/hotness.php
+++ b/qa-include/db/hotness.php
@@ -61,7 +61,7 @@ function qa_db_hotness_update($firstpostid, $lastpostid = null, $viewincrement =
 	if (!isset($lastpostid))
 		$lastpostid = $firstpostid;
 
-	$query = "UPDATE ^posts AS x, (SELECT parents.postid, parents.created AS qcreated, COALESCE(MAX(children.created), parents.created) as acreated, COUNT(children.postid) AS acount, parents.netvotes, parents.views FROM ^posts AS parents LEFT JOIN ^posts AS children ON parents.postid=children.parentid AND children.type='A' WHERE parents.postid BETWEEN # AND # GROUP BY postid) AS a SET x.hotness=(" .
+	$query = "UPDATE ^posts AS x, (SELECT parents.postid, MAX(parents.created) AS qcreated, COALESCE(MAX(children.created), MAX(parents.created)) as acreated, COUNT(children.postid) AS acount, MAX(parents.netvotes) AS netvotes, MAX(parents.views) AS views FROM ^posts AS parents LEFT JOIN ^posts AS children ON parents.postid=children.parentid AND children.type='A' WHERE parents.postid BETWEEN # AND # GROUP BY postid) AS a SET x.hotness=(" .
 		'((TO_DAYS(a.qcreated)-734138)*86400.0+TIME_TO_SEC(a.qcreated))*# + ' . // zero-point is Jan 1, 2010
 		'((TO_DAYS(a.acreated)-734138)*86400.0+TIME_TO_SEC(a.acreated))*# + ' .
 		'(a.acount+0.0)*# + ' .

--- a/qa-include/db/selects.php
+++ b/qa-include/db/selects.php
@@ -892,7 +892,7 @@ function qa_db_search_posts_selectspec($voteuserid, $titlewords, $contentwords, 
 
 	$selectspec['columns'][] = 'score';
 	$selectspec['columns'][] = 'matchparts';
-	$selectspec['source'] .= " JOIN (SELECT questionid, SUM(score)+2*(LOG(#)*(^posts.hotness-(SELECT MIN(hotness) FROM ^posts WHERE type='Q'))/((SELECT MAX(hotness) FROM ^posts WHERE type='Q')-(SELECT MIN(hotness) FROM ^posts WHERE type='Q')))+LOG(questionid)/1000000 AS score, GROUP_CONCAT(CONCAT_WS(':', matchposttype, matchpostid, ROUND(score,3))) AS matchparts FROM (";
+	$selectspec['source'] .= " JOIN (SELECT questionid, SUM(score)+2*(LOG(#)*(MAX(^posts.hotness)-(SELECT MIN(hotness) FROM ^posts WHERE type='Q'))/((SELECT MAX(hotness) FROM ^posts WHERE type='Q')-(SELECT MIN(hotness) FROM ^posts WHERE type='Q')))+LOG(questionid)/1000000 AS score, GROUP_CONCAT(CONCAT_WS(':', matchposttype, matchpostid, ROUND(score,3))) AS matchparts FROM (";
 	$selectspec['sortdesc'] = 'score';
 	array_push($selectspec['arguments'], QA_IGNORED_WORDS_FREQ);
 
@@ -1070,19 +1070,35 @@ function qa_db_category_nav_selectspec($slugsorid, $isid, $ispostid = false, $fu
 		'SELECT categoryid FROM ^categories WHERE ' . $identifiersql, // gen below
 	);
 
+	$columns = array(
+		'parentid' => '^categories.parentid',
+		'title' => '^categories.title',
+		'tags' => '^categories.tags',
+		'qcount' => '^categories.qcount',
+		'position' => '^categories.position',
+	);
+
+	if ($full) {
+		foreach ($columns as $alias => $column) {
+			$columns[$alias] = 'MAX(' . $column . ')';
+		}
+
+		$columns['childcount'] = 'COUNT(child.categoryid)';
+		$columns['content'] = 'MAX(^categories.content)';
+		$columns['backpath'] = 'MAX(^categories.backpath)';
+	}
+
+	array_unshift($columns, '^categories.categoryid');
+
 	$selectspec = array(
-		'columns' => array('^categories.categoryid', '^categories.parentid', 'title' => '^categories.title', 'tags' => '^categories.tags', '^categories.qcount', '^categories.position'),
-		'source' => '^categories JOIN (' . implode(' UNION ', $parentselects) . ') y ON ^categories.parentid<=>parentkey' . ($full ? ' LEFT JOIN ^categories AS child ON child.parentid=^categories.categoryid GROUP BY ^categories.categoryid' : '') . ' ORDER BY ^categories.position',
+		'columns' => $columns,
+		'source' => '^categories JOIN (' . implode(' UNION ', $parentselects) . ') y ON ^categories.parentid<=>parentkey' .
+			($full ? ' LEFT JOIN ^categories AS child ON child.parentid=^categories.categoryid GROUP BY ^categories.categoryid' : '') .
+			' ORDER BY ^categories.position',
 		'arguments' => array($slugsorid, $slugsorid, $slugsorid, $slugsorid),
 		'arraykey' => 'categoryid',
 		'sortasc' => 'position',
 	);
-
-	if ($full) {
-		$selectspec['columns']['childcount'] = 'COUNT(child.categoryid)';
-		$selectspec['columns']['content'] = '^categories.content';
-		$selectspec['columns']['backpath'] = '^categories.backpath';
-	}
 
 	return $selectspec;
 }


### PR DESCRIPTION
There were a few missing ones. I haven't tested this much but the fix should be quite mechanical: if the ordering didn't originally care, then getting any of them should be the same.