### PR TITLE
Fix points recalculation when turning answers to comments

### DIFF
--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -1013,7 +1013,7 @@ function qa_answer_to_comment($oldanswer, $parentid, $content, $format, $text, $
 
 	qa_update_q_counts_for_a($question['postid']);
 	qa_db_ccount_update();
-	qa_db_points_update_ifuser($oldanswer['userid'], array('aposts', 'aselecteds', 'cposts', 'avoteds'));
+	qa_db_points_update_ifuser($oldanswer['userid'], array('aposts', 'aselecteds', 'cposts', 'avoteds', 'cvoteds'));
 
 	$useridvotes = qa_db_uservote_post_get($oldanswer['postid']);
 	foreach ($useridvotes as $voteruserid => $vote) {


### PR DESCRIPTION
Steps to reproduce
0. Prepare points so that you get X points per comment upvote
1. Add an answer
2. Upvote the answer
3. Turn answer to comment

You should have X less points as the points for the newly created comment are not taken into account.