### PR TITLE
Load process modules as early as possible for after_db_init plugins

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -409,6 +409,8 @@ function qa_initialize_postdb_plugins()
 
 	$qa_pluginManager->loadPluginsAfterDbInit();
 	qa_load_override_files();
+
+	qa_report_process_stage('plugins_loaded');
 }
 
 


### PR DESCRIPTION
Check these 3 lines: https://github.com/q2a/question2answer/blob/19be025e12d3d5c8bdfbfcaec2b39df395a4be00/qa-include/qa-page.php#L34-L36

You can see the `after_db_init` plugins don't get the `init_page` method called. This arguably makes sense: on one hand there should be a method called as early as possible (and it even makes sense for it to be called before the db connects) but on the other we should not remove the ability for `after_db_init` `process`es to also execute early in the bootstrap process.

The quick fix would be to try to load the `process` modules immediately after they have been registered. This can be done just by making a call to `qa_report_process_stage()` right after the modules are loaded. As at this point all plugins are fully loaded it could make sense to call it `plugins_loaded`.

This not only adds a possible useful feature (being able to listen to that event or method, actually) but also it helps in backwards compatibility as this respects more closely the module load order from v1.7.

If you merge this, I will update the docs.