### PR TITLE
Added anchor to be able to link to admin plugins

### DIFF
--- a/qa-include/pages/admin/admin-plugins.php
+++ b/qa-include/pages/admin/admin-plugins.php
@@ -194,7 +194,9 @@ if (!empty($fileSystemPlugins)) {
 		$beforeDbInit = isset($metadata['load_order']) && $metadata['load_order'] === 'before_db_init';
 		$enabled = $beforeDbInit || !$allowDisable || in_array($pluginDirectory, $enabledPlugins);
 
-		$pluginhtml = $namehtml . ' ' . $authorhtml . ' ' . $updatehtml . '<br>';
+		$slugid = qa_slugify($metadata['name']);
+		$anchorhtml = '<a id="'.$slugid.'" href="'.qa_self_html().'#'.$slugid.'">🔗</a> ';
+		$pluginhtml = $anchorhtml . $namehtml . ' ' . $authorhtml . ' ' . $updatehtml . '<br>';
 		$pluginhtml .= $deschtml . (strlen($deschtml) > 0 ? '<br>' : '');
 		$pluginhtml .= '<small style="color:#666">' . qa_html($pluginDirectoryPath) . '/</small>';
 


### PR DESCRIPTION
Adds a link icon in front of each plugin. Very helpful if you need to quickly jump to the plugins from other pages. The qa_admin_plugin_options_path() changes with each new installation. This implementation gives a unique and unchanging link. Feel free to change the icon.

Examples:
`/admin/plugins#tagging-tools`
`/admin/plugins#prevent-simultaneous-edits`

![image](https://user-images.githubusercontent.com/6764548/34078336-fba4e9e2-e320-11e7-95db-99958192f0a6.png)

