### PR TITLE
Updated htmLawed to v1.2.4.1 - 12 September 2017.

### DIFF
--- a/qa-include/vendor/htmLawed.php
+++ b/qa-include/vendor/htmLawed.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-htmLawed 1.2.4, 31 August 2017
+htmLawed 1.2.4.1, 12 September 2017
 Copyright Santosh Patnaik
 Dual licensed with LGPL 3 and GPL 2+
 A PHP Labware internal utility - www.bioinformatics.org/phplabware/internal_utilities/htmLawed
@@ -387,10 +387,10 @@ return $r;
 function hl_spec($t){
 // final $spec
 $s = array();
-function hl_aux1($m){
+if(!function_exists('hl_aux1')){function hl_aux1($m){
  return substr(str_replace(array(";", "|", "~", " ", ",", "/", "(", ")", '`"'), array("\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", '"'), $m[0]), 1, -1);
-}
-$t = str_replace(array("\t", "\r", "\n", ' '), '', preg_replace_callback('/"(?>(`.|[^"])*)"/sm', 'hl_aux1', trim($t)));
+}}
+$t = str_replace(array("\t", "\r", "\n", ' '), '', preg_replace_callback('/"(?>(`.|[^"])*)"/sm', 'hl_aux1', trim($t))); 
 for($i = count(($t = explode(';', $t))); --$i>=0;){
  $w = $t[$i];
  if(empty($w) or ($e = strpos($w, '=')) === false or !strlen(($a =  substr($w, $e+1)))){continue;}
@@ -669,9 +669,9 @@ return '';
 function hl_tidy($t, $w, $p){
 // tidy/compact HTM
 if(strpos(' pre,script,textarea', "$p,")){return $t;}
-function hl_aux2($m){
+if(!function_exists('hl_aux2')){function hl_aux2($m){
  return $m[1]. str_replace(array("<", ">", "\n", "\r", "\t", ' '), array("\x01", "\x02", "\x03", "\x04", "\x05", "\x07"), $m[3]). $m[4];
-}
+}}
 $t = preg_replace(array('`(<\w[^>]*(?<!/)>)\s+`', '`\s+`', '`(<\w[^>]*(?<!/)>) `'), array(' $1', ' ', '$1'), preg_replace_callback(array('`(<(!\[CDATA\[))(.+?)(\]\]>)`sm', '`(<(!--))(.+?)(-->)`sm', '`(<(pre|script|textarea)[^>]*?>)(.+?)(</\2>)`sm'), 'hl_aux2', $t));
 if(($w = strtolower($w)) == -1){
  return str_replace(array("\x01", "\x02", "\x03", "\x04", "\x05", "\x07"), array('<', '>', "\n", "\r", "\t", ' '), $t);
@@ -725,5 +725,5 @@ return str_replace(array("\x01", "\x02", "\x03", "\x04", "\x05", "\x07"), array(
 
 function hl_version(){
 // version
-return '1.2.4';
+return '1.2.4.1';
 }


### PR DESCRIPTION
Bug Fix:
1.2.4.1 - 12 September 2017. Corrects a function re-declaration bug introduced in version 1.2.4

Above file taken from http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/