### PR TITLE
Updated PHPMailer to v5.2.26

### DIFF
--- a/qa-include/vendor/PHPMailer/class.phpmailer.php
+++ b/qa-include/vendor/PHPMailer/class.phpmailer.php
@@ -31,7 +31,7 @@ class PHPMailer
      * The PHPMailer Version number.
      * @var string
      */
-    public $Version = '5.2.25';
+    public $Version = '5.2.26';
 
     /**
      * Email priority.
@@ -659,6 +659,8 @@ class PHPMailer
         if ($exceptions !== null) {
             $this->exceptions = (boolean)$exceptions;
         }
+        //Pick an appropriate debug output format automatically
+        $this->Debugoutput = (strpos(PHP_SAPI, 'cli') !== false ? 'echo' : 'html');
     }
 
     /**

--- a/qa-include/vendor/PHPMailer/class.smtp.php
+++ b/qa-include/vendor/PHPMailer/class.smtp.php
@@ -30,7 +30,7 @@ class SMTP
      * The PHPMailer SMTP version number.
      * @var string
      */
-    const VERSION = '5.2.25';
+    const VERSION = '5.2.26';
 
     /**
      * SMTP line break constant.
@@ -81,7 +81,7 @@ class SMTP
      * @deprecated Use the `VERSION` constant instead
      * @see SMTP::VERSION
      */
-    public $Version = '5.2.25';
+    public $Version = '5.2.26';
 
     /**
      * SMTP server port number.


### PR DESCRIPTION
Bug fix:
Minor security backport from 6.0 - set Debugoutput in constructor according to SAPI in use, avoiding potential XSS in default debug output. Thanks to Bankde Eakasit for spotting it.

ref:  https://github.com/PHPMailer/PHPMailer/releases