### PR TITLE
Update cached tag count when deleting posts

### DIFF
--- a/qa-include/app/post-create.php
+++ b/qa-include/app/post-create.php
@@ -124,6 +124,7 @@ function qa_update_counts_for_q($postid)
 	qa_db_unaqcount_update();
 	qa_db_unselqcount_update();
 	qa_db_unupaqcount_update();
+	qa_db_tagcount_update();
 }
 
 

--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -106,6 +106,9 @@ function qa_question_set_content($oldquestion, $title, $content, $format, $text,
 
 	} elseif ($oldquestion['type'] == 'Q') { // not hidden or queued
 		qa_post_index($oldquestion['postid'], 'Q', $oldquestion['postid'], $oldquestion['parentid'], $title, $content, $format, $text, $tagstring, $oldquestion['categoryid']);
+		if ($tagschanged) {
+			qa_db_tagcount_update();
+		}
 	}
 
 	$eventparams = array(

--- a/qa-include/plugins/qa-search-basic.php
+++ b/qa-include/plugins/qa-search-basic.php
@@ -68,7 +68,6 @@ class qa_search_basic
 		qa_db_word_contentcount_update(array_keys($contentwordidcounts));
 		qa_db_word_tagwordcount_update($tagwordids);
 		qa_db_word_tagcount_update($wholetagids);
-		qa_db_tagcount_update();
 	}
 
 	public function unindex_post($postid)
@@ -90,7 +89,6 @@ class qa_search_basic
 		$wholetagids = qa_db_posttags_get_post_wordids($postid);
 		qa_db_posttags_delete_post($postid);
 		qa_db_word_tagcount_update($wholetagids);
-		qa_db_tagcount_update();
 	}
 
 	public function move_post($postid, $categoryid)

--- a/qa-include/plugins/qa-search-basic.php
+++ b/qa-include/plugins/qa-search-basic.php
@@ -90,6 +90,7 @@ class qa_search_basic
 		$wholetagids = qa_db_posttags_get_post_wordids($postid);
 		qa_db_posttags_delete_post($postid);
 		qa_db_word_tagcount_update($wholetagids);
+		qa_db_tagcount_update();
 	}
 
 	public function move_post($postid, $categoryid)


### PR DESCRIPTION
To see this bug create a question with 2 new tags. Delete the question. Set the tag list length to 2. Navigate to the /tags page. Go to the last page. It should appear blank.

The cached tag count is not being updated on question removal.

I also removed the cache update away from the basic search plugin because the cache should be updated regardless of the search plugin that is being used.