### PR TITLE
Fix some scenarios where ^userpoints records are not present and generate issues

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -456,6 +456,17 @@ if (QA_FINAL_EXTERNAL_USERS) {
 				require_once QA_INCLUDE_DIR . 'db/selects.php';
 				$qa_cached_logged_in_user = qa_db_get_pending_result('loggedinuser', qa_db_user_account_selectspec($userid, true));
 
+				// If the site is configured to share the ^users table then there might not be a record in the
+				// ^userpoints table so this creates it
+				if ($qa_cached_logged_in_user['points'] === null) {
+					require_once QA_INCLUDE_DIR . 'db/points.php';
+					require_once QA_INCLUDE_DIR . 'db/users.php';
+
+					qa_db_points_update_ifuser($userid, null);
+					qa_db_uapprovecount_update();
+					$qa_cached_logged_in_user = qa_db_single_select(qa_db_user_account_selectspec($userid, true));
+				}
+
 				if (!isset($qa_cached_logged_in_user)) {
 					// the user can no longer be found (should only apply to deleted users)
 					qa_clear_session_user();

--- a/qa-include/db/selects.php
+++ b/qa-include/db/selects.php
@@ -1523,9 +1523,17 @@ function qa_db_top_users_selectspec($start, $count = null)
 		);
 	}
 
+	// If the site is configured to share the ^users table then there might not be a record in the ^userpoints table
+	if (defined('QA_MYSQL_USERS_PREFIX')) {
+		$basePoints = (int)qa_opt('points_base');
+		$source = '^users JOIN (SELECT ^users.userid, COALESCE(points,' . $basePoints . ') AS points FROM ^users LEFT JOIN ^userpoints ON ^users.userid=^userpoints.userid ORDER BY points DESC LIMIT #,#) y ON ^users.userid=y.userid';
+	} else {
+		$source = '^users JOIN (SELECT userid FROM ^userpoints ORDER BY points DESC LIMIT #,#) y ON ^users.userid=y.userid JOIN ^userpoints ON ^users.userid=^userpoints.userid';;
+	}
+
 	return array(
 		'columns' => array('^users.userid', 'handle', 'points', 'flags', '^users.email', 'avatarblobid' => 'BINARY avatarblobid', 'avatarwidth', 'avatarheight'),
-		'source' => '^users JOIN (SELECT userid FROM ^userpoints ORDER BY points DESC LIMIT #,#) y ON ^users.userid=y.userid JOIN ^userpoints ON ^users.userid=^userpoints.userid',
+		'source' => $source,
 		'arguments' => array($start, $count),
 		'arraykey' => 'userid',
 		'sortdesc' => 'points',


### PR DESCRIPTION
Assuming a user is overriding the `QA_MYSQL_USERS_PREFIX` then there are different sites each with its own `^userpoints` table. The thing is when a site creates a user then that site (and only that site) executes this line: https://github.com/q2a/question2answer/blob/cfec3c0155817ffba49b06435a05ebb3ef9859a1/qa-include/app/users-edit.php#L192

As sites are independent I don't think making a site communicate to each other the creation of the user would make any sense.

That means having to cope with the fact that there might be records in the `^users` table that are not in the `^userpoints` table. I don't think this is a big deal.

The current issue can be seen when listing top users. The query uses an `INNER JOIN` against the `userpoints` table which immediately removes all non present users. The suggestion would be to make a `LEFT JOIN`. It will make queries a bit slower but I don't think there any other way. To compensate, the fix also checks if there are multiple sites sharing the same `^users` table so that the most performant query is used.