### PR TITLE
Fix anonymous user images not being displayed

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -650,9 +650,6 @@ if (QA_FINAL_EXTERNAL_USERS) {
 		if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
 		require_once QA_INCLUDE_DIR . 'app/format.php';
-		if (strlen($handle) == 0) {
-			return null;
-		}
 
 		$avatarSource = qa_get_user_avatar_source($flags, $email, $blobId);
 
@@ -665,6 +662,9 @@ if (QA_FINAL_EXTERNAL_USERS) {
 				break;
 			case 'local-default':
 				$html = qa_get_avatar_blob_html(qa_opt('avatar_default_blobid'), qa_opt('avatar_default_width'), qa_opt('avatar_default_height'), $size, $padding);
+				if (strlen($handle) == 0) {
+					return $html;
+				}
 				break;
 			default: // NULL
 				return null;


### PR DESCRIPTION
The function is returning too early so anonymous users don't get to be assigned a default image in question lists. The default image should be displayed regardless of the user being anonymous or not. The link to the user profile should not be displayed for anonymous users.