### PR TITLE
Added placeholder "Search..." for search box

### DIFF
--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -742,4 +742,14 @@ class qa_html_theme extends qa_html_theme_base
 			'</div>' .
 			'</div>';
 	}
+	
+	/**
+	 * Adds placeholder "Search..." for search box
+	 *
+	 * @since Snow 1.4
+	 */    
+	public function search_field($search)
+	{
+		$this->output('<input type="text" ' .'placeholder="' . $search['button_label'] . '..." ' . $search['field_tags'] . ' value="' . @$search['value'] . '" class="qa-search-field"/>');
+	}
 }


### PR DESCRIPTION
On mobile search box looks confusing if it is for search or ask a question so added this placeholder.
<img width="495" alt="screen shot 2018-03-11 at 8 45 30 pm" src="https://user-images.githubusercontent.com/6511264/37264953-83fd1e66-256d-11e8-94ab-43a91b8105cd.png">

After adding placeholder it looks like this.
<img width="518" alt="screen shot 2018-03-11 at 8 48 43 pm" src="https://user-images.githubusercontent.com/6511264/37264975-a8eccce4-256d-11e8-8b0a-72b255c1ffd9.png">
