### PR TITLE
Fix another PHP 7.2 count warning

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -381,8 +381,8 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 		if (@$options['categoryview'] && isset($post['categoryname']) && isset($post['categorybackpath'])) {
 			$favoriteclass = '';
 
-			if (count(@$favoritemap['category'])) {
-				if (@$favoritemap['category'][$post['categorybackpath']]) {
+			if (isset($favoritemap['category']) && !empty($favoritemap['category'])) {
+				if (isset($favoritemap['category'][$post['categorybackpath']])) {
 					$favoriteclass = ' qa-cat-favorited';
 				} else {
 					foreach ($favoritemap['category'] as $categorybackpath => $dummy) {


### PR DESCRIPTION
Technically, the most appropriate check would be: `isset()`, `is_array()`, `!empty()`. However, as we know it is an array or it is not set we can remove the `is_array()` check. Furthermore, I think it is always set... but maybe I'm missing something.