### PR TITLE
Add jquery and other dependencies before addon dependencies

### DIFF
--- a/qa-include/app/page.php
+++ b/qa-include/app/page.php
@@ -360,7 +360,7 @@ function qa_output_content($qa_content)
 		$qa_content['script'] = array();
 	}
 
-	$qa_content['script'] = array_merge($qa_content['script'], $script);
+	$qa_content['script'] = array_merge($script, $qa_content['script']);
 
 	// Load the appropriate theme class and output the page
 


### PR DESCRIPTION
This way plugins can rely on jQuery in that point. I don't think this should break any currently existing plugins as currently the plugins that try to use jQuery in that point would not be able to do so, which means the order would not matter to them.