### PR TITLE
Push footer to bottom on SnowFlat theme

### DIFF
--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -76,6 +76,8 @@ html {
 html, body {
 	margin: 0;
 	padding: 0;
+	height: 100%;
+	position: relative;
 }
 
 body {
@@ -820,6 +822,11 @@ blockquote p {
 	margin: 10px auto;
 	padding: 0 10px;
 	*zoom: 1;
+	min-height: 100vh;
+	overflow: hidden;
+	display: block;
+	position: relative;
+	padding-bottom: 33px;
 }
 
 @media (min-width: 980px) {
@@ -3188,6 +3195,9 @@ input[type="submit"], button {
 	margin-bottom: 0;
 	font-size: 12px;
 	line-height: 12px;
+	position: fixed;
+	bottom: 0;
+	width: 100%;
 }
 .qa-footer a {
 	color: #fff;


### PR DESCRIPTION
Applies footer and content wrapper styles to push and keep footer
to bottom when main content is almost empty (or less than viewport height).

It also provides enough room to correctly render main content without overlapping
should main content scroll down.

REF:

https://medium.com/@zerox/keep-that-damn-footer-at-the-bottom-c7a921cb9551