### PR TITLE
Avoid sending emails to blocked and unapproved users

### DIFF
--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -376,7 +376,7 @@ function qa_db_user_levels_set($userid, $userlevels)
 function qa_db_users_get_mailing_next($lastuserid, $count)
 {
 	return qa_db_read_all_assoc(qa_db_query_sub(
-		'SELECT userid, email, handle, emailcode, flags FROM ^users WHERE userid># ORDER BY userid LIMIT #',
+		'SELECT userid, email, handle, emailcode, flags, level FROM ^users WHERE userid># ORDER BY userid LIMIT #',
 		$lastuserid, $count
 	));
 }


### PR DESCRIPTION
It could be done by filtering users out from the query itself. However, the counting of users would have to run using a non-indexed query. I think that's why users not willing to receive the email were filtered out in a similar way in the first place.