### PR TITLE
Remove essential CKEditor configuration from config.js file

### DIFF
--- a/qa-plugin/wysiwyg-editor/ckeditor/config.js
+++ b/qa-plugin/wysiwyg-editor/ckeditor/config.js
@@ -27,9 +27,6 @@ CKEDITOR.editorConfig = function( config ) {
 	// Make dialogs simpler
 	config.removeDialogTabs = 'image:advanced;link:advanced;table:advanced';
 
-	// Use form upload instead of XHR
-	config.filebrowserUploadMethod = 'form';
-
 	// Use native spell checking (note: Ctrl+right-click is required for native context menu)
 	config.disableNativeSpellChecker = false;
 

--- a/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
+++ b/qa-plugin/wysiwyg-editor/qa-wysiwyg-editor.php
@@ -170,6 +170,7 @@ class qa_wysiwyg_editor
 				// File uploads
 				($uploadimages ? "	filebrowserImageUploadUrl: $imageUploadUrl," : ""),
 				($uploadall ? "	filebrowserUploadUrl: $fileUploadUrl," : ""),
+				"	filebrowserUploadMethod: 'form',", // Use form upload instead of XHR
 
 				// Set language to Q2A site language, falling back to English if not available.
 				"	defaultLanguage: 'en',",


### PR DESCRIPTION
Some CKEditor configurations are essential for Q2A to interact with CKEditor. Those configurations should not be stored inside the ckeditor directory as it might be overriden by the instructions in the `CUSTOMIZE.md` file (which I believe they're OK!).

The rest of the configurations in the config.js file could still be moved the thing is that then the opposite will happen: Q2A will override them. That's why I think if they are essential, then they should not be overridable. Otherwise, they should.