### PR TITLE
Remove some unnecessary SQL queries

### DIFF
--- a/qa-include/app/users-edit.php
+++ b/qa-include/app/users-edit.php
@@ -520,9 +520,12 @@ function qa_set_user_avatar($userid, $imagedata, $oldblobid = null)
 		$newblobid = qa_create_blob($imagedata, 'jpeg', null, $userid, null, qa_remote_ip_address());
 
 		if (isset($newblobid)) {
-			qa_db_user_set($userid, 'avatarblobid', $newblobid);
-			qa_db_user_set($userid, 'avatarwidth', $width);
-			qa_db_user_set($userid, 'avatarheight', $height);
+			qa_db_user_set($userid, array(
+				'avatarblobid' => $newblobid,
+				'avatarwidth' => $width,
+				'avatarheight' => $height,
+			));
+
 			qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_AVATAR, true);
 			qa_db_user_set_flag($userid, QA_USER_FLAGS_SHOW_GRAVATAR, false);
 

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -289,8 +289,10 @@ if (QA_FINAL_EXTERNAL_USERS) {
 
 			if (empty($userinfo['sessioncode']) || ($source !== $userinfo['sessionsource'])) {
 				$sessioncode = qa_db_user_rand_sessioncode();
-				qa_db_user_set($userid, 'sessioncode', $sessioncode);
-				qa_db_user_set($userid, 'sessionsource', $source);
+				qa_db_user_set($userid, array(
+					'sessioncode' => $sessioncode,
+					'sessionsource' => $source,
+				));
 			} else
 				$sessioncode = $userinfo['sessioncode'];
 

--- a/qa-include/db/users.php
+++ b/qa-include/db/users.php
@@ -164,17 +164,30 @@ function qa_db_user_get_handle_userids($handles)
 
 
 /**
- * Set $field of $userid to $value in the database users table
- * @param $userid
- * @param $field
- * @param $value
+ * Set $field of $userid to $value in the database users table. If the $fields parameter is an array, the $value
+ * parameter is ignored and each element of the array is treated as a key-value pair of user fields and values.
+ * @param mixed $userid
+ * @param string|array $fields
+ * @param string|null $value
  */
-function qa_db_user_set($userid, $field, $value)
+function qa_db_user_set($userid, $fields, $value = null)
 {
-	qa_db_query_sub(
-		'UPDATE ^users SET ' . qa_db_escape_string($field) . '=$ WHERE userid=$',
-		$value, $userid
-	);
+	if (!is_array($fields)) {
+		$fields = array(
+			$fields => $value,
+		);
+	}
+
+	$sql = 'UPDATE ^users SET ';
+	foreach ($fields as $field => $fieldValue) {
+		$sql .= qa_db_escape_string($field) . ' = $, ';
+	}
+	$sql = substr($sql, 0, -2) . ' WHERE userid = $';
+
+	$params = array_values($fields);
+	$params[] = $userid;
+
+	qa_db_query_sub_params($sql, $params);
 }
 
 

--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -163,9 +163,12 @@ if (!QA_FINAL_EXTERNAL_USERS) {
 					if (isset($useraccount['avatarblobid'])) {
 						require_once QA_INCLUDE_DIR . 'app/blobs.php';
 
-						qa_db_user_set($userid, 'avatarblobid', null);
-						qa_db_user_set($userid, 'avatarwidth', null);
-						qa_db_user_set($userid, 'avatarheight', null);
+						qa_db_user_set($userid, array(
+							'avatarblobid' => null,
+							'avatarwidth' => null,
+							'avatarheight' => null,
+						));
+
 						qa_delete_blob($useraccount['avatarblobid']);
 					}
 				}

--- a/qa-include/qa-db.php
+++ b/qa-include/qa-db.php
@@ -372,14 +372,26 @@ function qa_db_apply_sub($query, $arguments)
 
 /**
  * Run $query after substituting ^, # and $ symbols, and return the result resource (or call fail handler).
- * @param $query
+ * @param string $query
  * @return mixed
  */
 function qa_db_query_sub($query) // arguments for substitution retrieved using func_get_args()
 {
 	$funcargs = func_get_args();
 
-	return qa_db_query_raw(qa_db_apply_sub($query, array_slice($funcargs, 1)));
+	return qa_db_query_sub_params($query, array_slice($funcargs, 1));
+}
+
+/**
+ * Run $query after substituting ^, # and $ symbols, and return the result resource (or call fail handler).
+ * Query parameters are passed as an array.
+ * @param string $query
+ * @param array $params
+ * @return mixed
+ */
+function qa_db_query_sub_params($query, $params)
+{
+	return qa_db_query_raw(qa_db_apply_sub($query, $params));
 }
 
 


### PR DESCRIPTION
This is not just saving a few SQL queries but also saving some additional queries that addons may run.

Also I'm adding the `qa_db_query_sub_params()` function which is much more flexible than its sibling `qa_db_query_sub()`. I noticed that I ended up needing it in most of my plugins.

#666 :smiling_imp: 