### PR TITLE
Fix closed questions by selected answer not displayed as closed

### DIFF
--- a/qa-include/ajax/answer.php
+++ b/qa-include/ajax/answer.php
@@ -37,7 +37,7 @@ list($question, $childposts) = qa_db_select_with_pending(
 
 // Check if the question exists, is not closed, and whether the user has permission to do this
 
-if (@$question['basetype'] == 'Q' && !isset($question['closedbyid']) && !qa_user_post_permit_error('permit_post_a', $question, QA_LIMIT_ANSWERS)) {
+if (@$question['basetype'] == 'Q' && !isset($question['closedbyid']) && (!qa_opt('do_close_on_select') || !isset($question['selchildid'])) && !qa_user_post_permit_error('permit_post_a', $question, QA_LIMIT_ANSWERS)) {
 	require_once QA_INCLUDE_DIR . 'app/captcha.php';
 	require_once QA_INCLUDE_DIR . 'app/format.php';
 	require_once QA_INCLUDE_DIR . 'app/post-create.php';

--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -320,7 +320,7 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 	$fields['tags'] = 'id="' . qa_html($elementid) . '"';
 
 	$fields['classes'] = ($isquestion && $favoritedview && @$post['userfavoriteq']) ? 'qa-q-favorited' : '';
-	if ($isquestion && isset($post['closedbyid']))
+	if ($isquestion && (isset($post['closedbyid']) || (qa_opt('do_close_on_select') && isset($post['selchildid']))))
 		$fields['classes'] = ltrim($fields['classes'] . ' qa-q-closed');
 
 	if ($microdata) {
@@ -617,7 +617,7 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 		( // otherwise check if one of these conditions is fulfilled...
 			(!isset($post['created'])) || // ... we didn't show the created time (should never happen in practice)
 			($post['hidden'] && ($post['updatetype'] == QA_UPDATE_VISIBLE)) || // ... the post was hidden as the last action
-			(isset($post['closedbyid']) && ($post['updatetype'] == QA_UPDATE_CLOSED)) || // ... the post was closed as the last action
+			((isset($post['closedbyid']) || (qa_opt('do_close_on_select') && isset($post['selchildid']))) && $post['updatetype'] == QA_UPDATE_CLOSED) || // ... the post was closed as the last action
 			(abs($post['updated'] - $post['created']) > 300) || // ... or over 5 minutes passed between create and update times
 			($post['lastuserid'] != $post['userid']) // ... or it was updated by a different user
 		)
@@ -637,7 +637,7 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 				break;
 
 			case QA_UPDATE_CLOSED:
-				$langstring = isset($post['closedbyid']) ? 'main/closed' : 'main/reopened';
+				$langstring = isset($post['closedbyid']) || (qa_opt('do_close_on_select') && isset($post['selchildid'])) ? 'main/closed' : 'main/reopened';
 				break;
 
 			case QA_UPDATE_TAGS:
@@ -838,10 +838,11 @@ function qa_other_to_q_html_fields($question, $userid, $cookieid, $usershtml, $d
 			break;
 
 		case 'Q-' . QA_UPDATE_CLOSED:
+			$isClosed = isset($question['closedbyid']) || (qa_opt('do_close_on_select') && isset($question['selchildid']));
 			if (@$question['opersonal'])
-				$langstring = isset($question['closedbyid']) ? 'misc/your_q_closed' : 'misc/your_q_reopened';
+				$langstring = $isClosed ? 'misc/your_q_closed' : 'misc/your_q_reopened';
 			else
-				$langstring = isset($question['closedbyid']) ? 'main/closed' : 'main/reopened';
+				$langstring = $isClosed ? 'main/closed' : 'main/reopened';
 			break;
 
 		case 'Q-' . QA_UPDATE_TAGS:

--- a/qa-include/app/q-list.php
+++ b/qa-include/app/q-list.php
@@ -89,7 +89,7 @@ function qa_q_list_page_content($questions, $pagesize, $start, $count, $sometitl
 
 	$qa_content['q_list']['qs'] = array();
 
-	if (count($questions)) {
+	if (!empty($questions)) {
 		$qa_content['title'] = $sometitle;
 
 		$defaults = qa_post_html_defaults('Q');
@@ -97,10 +97,11 @@ function qa_q_list_page_content($questions, $pagesize, $start, $count, $sometitl
 			$defaults['categorypathprefix'] = $categorypathprefix;
 		}
 
+		$closeOnSelect = qa_opt('do_close_on_select');
 		foreach ($questions as $question) {
 			$fields = qa_any_to_q_html_fields($question, $userid, qa_cookie_get(), $usershtml, null, qa_post_html_options($question, $defaults));
 
-			if (!empty($fields['raw']['closedbyid'])) {
+			if (!empty($fields['raw']['closedbyid']) || (!empty($fields['raw']['selchildid']) && $closeOnSelect)) {
 				$fields['closed'] = array(
 					'state' => qa_lang_html('main/closed'),
 				);

--- a/qa-include/pages/question-view.php
+++ b/qa-include/pages/question-view.php
@@ -184,7 +184,7 @@ function qa_page_q_post_rules($post, $parentpost = null, $siblingposts = null, $
 
 	$rules['closeable'] = qa_opt('allow_close_questions') && $post['type'] == 'Q' && !$rules['closed'] && $permiterror_close_open === false;
 	// cannot reopen a question if it's been hidden, or if it was closed by someone else and you don't have global closing permissions
-	$rules['reopenable'] = $rules['closed'] && isset($post['closedbyid']) && $permiterror_close_open === false && !$post['hidden']
+	$rules['reopenable'] = $rules['closed'] && $permiterror_close_open === false && !$post['hidden']
 		&& ($notclosedbyother || !qa_user_permit_error('permit_close_q', null, $userlevel, true, $userfields));
 
 	$rules['moderatable'] = $post['queued'] && !$permiterror_moderate;
@@ -428,7 +428,7 @@ function qa_page_q_question_view($question, $parentquestion, $closepost, $usersh
 
 	// Information about the question that this question is a duplicate of (if appropriate)
 
-	if (isset($closepost)) {
+	if (isset($closepost) || (!empty($q_view['raw']['selchildid']) && qa_opt('do_close_on_select'))) {
 		if ($closepost['basetype'] == 'Q') {
 			if ($closepost['hidden']) {
 				// don't show link for hidden questions
@@ -455,6 +455,12 @@ function qa_page_q_question_view($question, $parentquestion, $closepost, $usersh
 				'content' => $viewer->get_html($closepost['content'], $closepost['format'], array(
 					'blockwordspreg' => qa_get_block_words_preg(),
 				)),
+			);
+		} else { // If closed by a selected answer due to the do_close_on_select setting being enabled
+			$q_view['closed'] = array(
+				'state' => qa_lang_html('main/closed'),
+				'label' => qa_lang_html('main/closed'),
+				'content' => '',
 			);
 		}
 	}

--- a/qa-include/qa-feed.php
+++ b/qa-include/qa-feed.php
@@ -337,7 +337,7 @@ foreach ($questions as $question) {
 				break;
 
 			case 'Q-' . QA_UPDATE_CLOSED:
-				$langstring = isset($question['closedbyid']) ? 'misc/feed_closed_prefix' : 'misc/feed_reopened_prefix';
+				$langstring = isset($question['closedbyid']) || ($question['selchildid'] && qa_opt('do_close_on_select')) ? 'misc/feed_closed_prefix' : 'misc/feed_reopened_prefix';
 				break;
 
 			case 'Q-' . QA_UPDATE_TAGS:


### PR DESCRIPTION
It seems the core doesn't properly handle the `do_close_on_select` setting. It seems the rules were the only ones that were taking care of that setting:

https://github.com/q2a/question2answer/blob/1f39ae44adf42c83042be631e39373893a3ec969/qa-include/pages/question-view.php#L121

The rest of the core only considers a non-null `closedbyid` as the indicator of a closed question. I can think of two options to fix this:

1. Allow answer ids in the `closedbyid` so that the selected answer takes the place of the note or question duplicate. This approach seems to be the best one but is a bit non-backwards compatible as now questions can be closed by answers. Also SQL queries that consider closed questions as non-null `closedbyid` would be accurate (note they are not accurate currently).
1. Change the interpretation of closed questions along the core. This approach is more backwards compatible. Better for a workaround.

In either case, the selection of answers should fire the appropriate events in questions.