### PR TITLE
Fix many phpcs complaints

### DIFF
--- a/qa-config-example.php
+++ b/qa-config-example.php
@@ -66,13 +66,13 @@
 /*
 	If you wish, you can define QA_MYSQL_USERS_PREFIX separately from QA_MYSQL_TABLE_PREFIX.
 	If so, tables containing information about user accounts (not including users' activity and points)
-	get the prefix of QA_MYSQL_TABLE_PREFIX. This allows multiple Q2A sites to have shared logins 
+	get the prefix of QA_MYSQL_TABLE_PREFIX. This allows multiple Q2A sites to have shared logins
 	and users, but separate posts and activity.
-	
-	If you have installed question2answer with default "qa_" prefix and want to setup a second 
-	installation, you define the QA_MYSQL_USERS_PREFIX as "qa_" so this new installation 
+
+	If you have installed question2answer with default "qa_" prefix and want to setup a second
+	installation, you define the QA_MYSQL_USERS_PREFIX as "qa_" so this new installation
 	can access the same database as the first installation.
-	
+
 	define('QA_MYSQL_USERS_PREFIX', 'sharedusers_');
 */
 
@@ -143,8 +143,8 @@
 /*
 	Out-of-the-box Joomla! 3.x integration - to integrate with your Joomla! site, define
 	QA_JOOMLA_INTEGRATE_PATH. as the full path to the Joomla! directory. If your Q2A
-    site is a subdirectory of your main Joomla site (recommended), you can specify
-    dirname(__DIR__) rather than the full path.
+	site is a subdirectory of your main Joomla site (recommended), you can specify
+	dirname(__DIR__) rather than the full path.
 	With this set, you do not need to set the QA_MYSQL_* constants above since these
 	will be taken from Joomla automatically. See online documentation for more details.
 

--- a/qa-include/Q2A/Util/Usage.php
+++ b/qa-include/Q2A/Util/Usage.php
@@ -109,7 +109,7 @@ class Q2A_Util_Usage
 		$totaldelta = $this->delta($this->startUsage, $this->getCurrent());
 		$stages = $this->stages;
 		$stages['total'] = $totaldelta;
-?>
+		?>
 		<style>
 		.debug-table { border-collapse: collapse; width: auto; margin: 20px auto; }
 		.debug-table th, .debug-table td { border: 1px solid #aaa; background-color: #ddd; padding: 5px 10px; }
@@ -155,7 +155,7 @@ class Q2A_Util_Usage
 				</tr>
 			</thead>
 		<tbody>
-<?php foreach ($stages as $stage => $stagedelta) : ?>
+		<?php foreach ($stages as $stage => $stagedelta) : ?>
 			<tr>
 				<td class="row-heading"><?php echo ucfirst($stage); ?></td>
 				<td><?php echo sprintf('%.1f', $stagedelta['clock'] * 1000); ?></td>
@@ -171,7 +171,7 @@ class Q2A_Util_Usage
 				<td><?php echo sprintf('%dk', $stagedelta['ram'] / 1024); ?></td>
 				<td><?php echo sprintf('%d%%', $stagedelta['ram'] ? ($stagedelta['ram'] * 100 / $totaldelta['ram']) : 0); ?></td>
 			</tr>
-<?php endforeach; ?>
+		<?php endforeach; ?>
 		</tbody>
 		</table>
 
@@ -190,7 +190,7 @@ class Q2A_Util_Usage
 			</tr>
 		</tbody>
 		</table>
-<?php
+		<?php
 	}
 
 

--- a/qa-include/pages/admin/admin-userfields.php
+++ b/qa-include/pages/admin/admin-userfields.php
@@ -100,7 +100,6 @@ elseif (qa_clicked('dosavefield')) {
 				}
 
 			} elseif (empty($errors)) { // creating a new user field
-
 				for ($attempt = 0; $attempt < 1000; $attempt++) {
 					$suffix = $attempt ? ('-' . (1 + $attempt)) : '';
 					$newtag = qa_substr(implode('-', qa_string_to_words($inname)), 0, QA_DB_MAX_PROFILE_TITLE_LENGTH - strlen($suffix)) . $suffix;

--- a/qa-include/pages/question-post.php
+++ b/qa-include/pages/question-post.php
@@ -809,7 +809,6 @@ function qa_page_q_edit_a_submit($answer, $question, $answers, $commentsfollows,
 					(($in['commenton'] != $answerid) && @$answers[$in['commenton']]['commentable'])
 				)
 			) { // convert to a comment
-
 				if (qa_user_limits_remaining(QA_LIMIT_COMMENTS)) { // already checked 'permit_post_c'
 					qa_answer_to_comment($answer, $in['commenton'], $in['content'], $in['format'], $in['text'], $setnotify,
 						$userid, $handle, $cookieid, $question, $answers, $commentsfollows, @$in['name'], $in['queued'], $in['silent']);

--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -89,7 +89,6 @@ if (!QA_FINAL_EXTERNAL_USERS) { // if we're using integrated user management, we
 		($loginlevel >= QA_USER_LEVEL_SUPER || $loginlevel > $maxuserlevel) &&
 		!qa_user_permit_error()
 	) { // can't change self - or someone on your level (or higher, obviously) unless you're a super admin
-
 		if ($loginlevel >= QA_USER_LEVEL_SUPER)
 			$maxlevelassign = QA_USER_LEVEL_SUPER;
 		elseif ($loginlevel >= QA_USER_LEVEL_ADMIN)

--- a/qa-include/plugins/qa-widget-ask-box.php
+++ b/qa-include/plugins/qa-widget-ask-box.php
@@ -42,7 +42,7 @@ class qa_ask_box
 		else
 			$params = null;
 
-?>
+		?>
 <div class="qa-ask-box">
 	<form method="post" action="<?php echo qa_path_html('ask', $params); ?>">
 		<table class="qa-form-tall-table" style="width:100%">
@@ -50,10 +50,10 @@ class qa_ask_box
 				<td class="qa-form-tall-label" style="width: 1px; padding:8px; white-space:nowrap; <?php echo ($region=='side') ? 'padding-bottom:0;' : 'text-align:right;'?>">
 					<?php echo strtr(qa_lang_html('question/ask_title'), array(' ' => '&nbsp;'))?>:
 				</td>
-<?php if ($region=='side') : ?>
+		<?php if ($region=='side') : ?>
 			</tr>
 			<tr>
-<?php endif; ?>
+		<?php endif; ?>
 				<td class="qa-form-tall-data" style="padding:8px;">
 					<input name="title" type="text" class="qa-form-tall-text" style="width:95%;">
 				</td>
@@ -62,6 +62,6 @@ class qa_ask_box
 		<input type="hidden" name="doask1" value="1">
 	</form>
 </div>
-<?php
+		<?php
 	}
 }

--- a/qa-plugin/facebook-login/qa-facebook-login.php
+++ b/qa-plugin/facebook-login/qa-facebook-login.php
@@ -57,7 +57,7 @@ class qa_facebook_login
 		else
 			$size = 'medium';
 
-?>
+		?>
 	<span id="fb-root" style="display:inline;"></span>
 	<script>
 	window.fbAsyncInit = function() {
@@ -82,7 +82,7 @@ class qa_facebook_login
 	</script>
 	<span class="fb-login-button" style="display:inline; vertical-align:middle;" size="<?php echo $size?>" <?php echo $logout ? 'autologoutlink="true"' : 'scope="email,user_about_me,user_location,user_website"'?>>
 	</span>
-<?php
+		<?php
 	}
 
 

--- a/qa-plugin/mouseover-layer/qa-mouseover-layer.php
+++ b/qa-plugin/mouseover-layer/qa-mouseover-layer.php
@@ -25,7 +25,6 @@ class qa_html_theme_layer extends qa_html_theme_base
 	public function q_list($q_list)
 	{
 		if (!empty($q_list['qs']) && qa_opt('mouseover_content_on')) { // first check it is not an empty list and the feature is turned on
-
 			// Collect the question ids of all items in the question list (so we can do this in one DB query)
 
 			$postids = array();


### PR DESCRIPTION
Just for reference, phpcs 3.3.1 is throwing all these:

```
qa-include/pages/admin/admin-userfields.php:102:39: error - Blank line found at start of control structure
qa-include/pages/question-post.php:811:15: error - Blank line found at start of control structure
qa-include/pages/user-profile.php:91:7: error - Blank line found at start of control structure
qa-include/Q2A/Util/Usage.php:112:1: error - Line indented incorrectly; expected 2 tabs, found 0
qa-include/Q2A/Util/Usage.php:158:1: error - Line indented incorrectly; expected at least 2 tabs, found 0
qa-include/Q2A/Util/Usage.php:193:1: error - Line indented incorrectly; expected at least 2 tabs, found 0
qa-include/plugins/qa-widget-ask-box.php:45:1: error - Line indented incorrectly; expected 2 tabs, found 0
qa-include/plugins/qa-widget-ask-box.php:53:1: error - Line indented incorrectly; expected at least 2 tabs, found 0
qa-include/plugins/qa-widget-ask-box.php:65:1: error - Line indented incorrectly; expected at least 2 tabs, found 0
qa-lang/es/qa-lang-admin.php:31:1: error - Expected 1 newline at end of file; 0 found
qa-plugin/facebook-login/qa-facebook-login.php:60:1: error - Line indented incorrectly; expected 2 tabs, found 0
qa-plugin/facebook-login/qa-facebook-login.php:85:1: error - Line indented incorrectly; expected at least 2 tabs, found 0
qa-plugin/mouseover-layer/qa-mouseover-layer.php:27:70: error - Blank line found at start of control structure
qa-config-example.php:69:1: error - Whitespace found at end of line
qa-config-example.php:71:1: error - Whitespace found at end of line
qa-config-example.php:72:1: error - Whitespace found at end of line
qa-config-example.php:73:1: error - Whitespace found at end of line
qa-config-example.php:75:1: error - Whitespace found at end of line
qa-config-example.php:146:1: error - Tabs must be used to indent lines; spaces are not allowed
qa-config-example.php:147:1: error - Tabs must be used to indent lines; spaces are not allowed
```