### PR TITLE
Avoid warning when a user has no favorite

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -381,7 +381,7 @@ function qa_post_html_fields($post, $userid, $cookieid, $usershtml, $dummy, $opt
 		if (@$options['categoryview'] && isset($post['categoryname']) && isset($post['categorybackpath'])) {
 			$favoriteclass = '';
 
-			if (count(@$favoritemap['category'])) {
+			if (isset($favoritemap['category']) && count(@$favoritemap['category'])) {
 				if (@$favoritemap['category'][$post['categorybackpath']]) {
 					$favoriteclass = ' qa-cat-favorited';
 				} else {


### PR DESCRIPTION
When a user has no favorite (ie: when `$favoritemap` is an empty array) then displaying for instance the main page, generates this warning:

    Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/html/q2a/qa-include/app/format.php on line 384

This patch avoids filling my Apache error logs with those warnings