### PR TITLE
Fix voting on follow-on questions

### DIFF
--- a/qa-include/pages/question-view.php
+++ b/qa-include/pages/question-view.php
@@ -851,10 +851,10 @@ function qa_page_q_comment_follow_list($question, $parent, $commentsfollows, $al
 			$skipfirst--;
 		} elseif ($commentfollow['basetype'] == 'C') {
 			$commentlist['cs'][$commentfollowid] = qa_page_q_comment_view($question, $parent, $commentfollow, $usershtml, $formrequested);
-
 		} elseif ($commentfollow['basetype'] == 'Q') {
 			$htmloptions = qa_post_html_options($commentfollow);
 			$htmloptions['avatarsize'] = qa_opt('avatar_q_page_c_size');
+			$htmloptions['voteview'] = false;
 
 			$commentlist['cs'][$commentfollowid] = qa_post_html_fields($commentfollow, $userid, $cookieid, $usershtml, null, $htmloptions);
 		}


### PR DESCRIPTION
This is how it looks in 1.8.2:

![image](https://user-images.githubusercontent.com/1449790/50490052-d65d9d00-09e9-11e9-9bca-01a4d08960c7.png)

Voting should just be removed