### PR TITLE
Rm lang key "caching_dir_public"

### DIFF
--- a/qa-include/lang/qa-lang-admin.php
+++ b/qa-include/lang/qa-lang-admin.php
@@ -59,7 +59,6 @@ return array(
 	'caching_delete_progress' => 'Deleted ^1 of ^2 cache files...',
 	'caching_dir_error' => 'The directory ^ defined as QA_CACHE_DIRECTORY is not writable by the web server.',
 	'caching_dir_missing' => 'Cache directory has not been defined.',
-	'caching_dir_public' => 'The directory ^ defined as QA_CACHE_DIRECTORY must be outside the public root.',
 	'caching_num_items' => 'Number of items in cache',
 	'caching_space_used' => 'Total size of cache',
 	'caching_title' => 'Caching',


### PR DESCRIPTION
This key isn't used since f394a34c54b938218e8bb92549ae3a1f480e6f8a . Removing
it ensures translators don't bother translating it for nothing