### PR TITLE
Fix selection of answers trying to close questions

### DIFF
--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -191,7 +191,7 @@ function qa_question_set_selchildid($userid, $handle, $cookieid, $oldquestion, $
 			'answer' => $answers[$selchildid],
 		));
 
-		if (empty($oldquestion['closed'])) {
+		if (empty($oldquestion['closed']) && qa_opt('do_close_on_select')) {
 			qa_db_post_set_closed($oldquestion['postid'], null, $userid, $lastip);
 
 			qa_report_event('q_close', $userid, $handle, $cookieid, array(


### PR DESCRIPTION
Steps to reproduce:
1. Disable `do_close_on_select`
2. Select an answer
3. The question is displayed as `reopened`

> If debugging is the process of removing bugs, then programming must be the process of putting them in