### PR TITLE
Category add and edit event

### DIFF
--- a/qa-include/pages/admin/admin-categories.php
+++ b/qa-include/pages/admin/admin-categories.php
@@ -218,15 +218,34 @@ if (qa_clicked('docancel')) {
 					$recalc = $hassubcategory && $inslug !== $editcategory['tags'];
 				}
 
+				qa_report_event('cat_edit', qa_get_logged_in_userid(), qa_get_logged_in_handle(), qa_cookie_get(), array(
+					'categoryid' => $editcategory['categoryid'],
+					'parentid' => @$inparentid,
+					'content' => @$incontent,
+					'position' => @$inposition,
+					'name' => $inname,
+					'slug' => $inslug
+				));
+
 				qa_redirect(qa_request(), array('edit' => $editcategory['categoryid'], 'saved' => true, 'recalc' => (int)$recalc));
 
 			} else { // creating a new one
 				$categoryid = qa_db_category_create($inparentid, $inname, $inslug);
+				
 
 				qa_db_category_set_content($categoryid, $incontent);
 
 				if (isset($inposition))
 					qa_db_category_set_position($categoryid, $inposition);
+
+				qa_report_event('cat_new', qa_get_logged_in_userid(), qa_get_logged_in_handle(), qa_cookie_get(), array(
+					'categoryid' => $categoryid,
+					'parentid' => $inparentid,
+					'content' => @$incontent,
+					'position' => @$inposition,
+					'name' => $inname,
+					'slug' => $inslug
+				));
 
 				qa_redirect(qa_request(), array('edit' => $inparentid, 'added' => true));
 			}

--- a/qa-include/pages/admin/admin-categories.php
+++ b/qa-include/pages/admin/admin-categories.php
@@ -225,7 +225,7 @@ if (qa_clicked('docancel')) {
 					'content' => isset($incontent)?$incontent:null,
 					'position' => isset($inposition)?$inposition:null,
 					'name' => $inname,
-					'slug' => $inslug
+					'slug' => $inslug,
 				));
 
 				qa_redirect(qa_request(), array('edit' => $editcategory['categoryid'], 'saved' => true, 'recalc' => (int)$recalc));
@@ -244,7 +244,7 @@ if (qa_clicked('docancel')) {
 					'content' => isset($incontent)?$incontent:null,
 					'position' => isset($inposition)?$inposition:null,
 					'name' => $inname,
-					'slug' => $inslug
+					'slug' => $inslug,
 				));
 
 				qa_redirect(qa_request(), array('edit' => $inparentid, 'added' => true));

--- a/qa-include/pages/admin/admin-categories.php
+++ b/qa-include/pages/admin/admin-categories.php
@@ -231,7 +231,6 @@ if (qa_clicked('docancel')) {
 
 			} else { // creating a new one
 				$categoryid = qa_db_category_create($inparentid, $inname, $inslug);
-				
 
 				qa_db_category_set_content($categoryid, $incontent);
 

--- a/qa-include/pages/admin/admin-categories.php
+++ b/qa-include/pages/admin/admin-categories.php
@@ -204,6 +204,7 @@ if (qa_clicked('docancel')) {
 		// Perform appropriate database action
 
 		if (empty($errors)) {
+			require_once QA_INCLUDE_DIR . 'app/cookies.php';
 			if (isset($editcategory['categoryid'])) { // changing existing category
 				qa_db_category_rename($editcategory['categoryid'], $inname, $inslug);
 
@@ -220,9 +221,9 @@ if (qa_clicked('docancel')) {
 
 				qa_report_event('cat_edit', qa_get_logged_in_userid(), qa_get_logged_in_handle(), qa_cookie_get(), array(
 					'categoryid' => $editcategory['categoryid'],
-					'parentid' => @$inparentid,
-					'content' => @$incontent,
-					'position' => @$inposition,
+					'parentid' => isset($inparentid)?$inparentid:null,
+					'content' => isset($incontent)?$incontent:null,
+					'position' => isset($inposition)?$inposition:null,
 					'name' => $inname,
 					'slug' => $inslug
 				));
@@ -240,8 +241,8 @@ if (qa_clicked('docancel')) {
 				qa_report_event('cat_new', qa_get_logged_in_userid(), qa_get_logged_in_handle(), qa_cookie_get(), array(
 					'categoryid' => $categoryid,
 					'parentid' => $inparentid,
-					'content' => @$incontent,
-					'position' => @$inposition,
+					'content' => isset($incontent)?$incontent:null,
+					'position' => isset($inposition)?$inposition:null,
 					'name' => $inname,
 					'slug' => $inslug
 				));


### PR DESCRIPTION
I think it is necessary to have these events to make plugins be able to set category meta right after the category is created and/or for eventlog