### PR TITLE
Fire u_delete_before event before deleting a user

### DIFF
--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -285,6 +285,11 @@ if (!QA_FINAL_EXTERNAL_USERS) {
 				if (qa_clicked('dodelete') && ($loginlevel >= QA_USER_LEVEL_ADMIN)) {
 					require_once QA_INCLUDE_DIR . 'app/users-edit.php';
 
+					qa_report_event('u_delete_before', $loginuserid, qa_get_logged_in_handle(), qa_cookie_get(), array(
+						'userid' => $userid,
+						'handle' => $useraccount['handle'],
+					));
+
 					qa_delete_user($userid);
 
 					qa_report_event('u_delete', $loginuserid, qa_get_logged_in_handle(), qa_cookie_get(), array(


### PR DESCRIPTION
This is useful whenever some action needs to be taken before deleting the user. For example, performing some action on their votes. Once the user is removed, it is not possible to access that information.

Changes to the events documentation have been added here: https://github.com/q2a/q2a.github.io/pull/25