### PR TITLE
Fix many failing SQL queries

### DIFF
--- a/qa-include/ajax/asktitle.php
+++ b/qa-include/ajax/asktitle.php
@@ -32,7 +32,7 @@ $doaskcheck = qa_opt('do_ask_check_qs');
 $doexampletags = qa_using_tags() && qa_opt('do_example_tags');
 
 if ($doaskcheck || $doexampletags) {
-	$countqs = max($doexampletags ? QA_DB_RETRIEVE_ASK_TAG_QS : 0, $doaskcheck ? qa_opt('page_size_ask_check_qs') : 0);
+	$countqs = max($doexampletags ? QA_DB_RETRIEVE_ASK_TAG_QS : 0, $doaskcheck ? (int)qa_opt('page_size_ask_check_qs') : 0);
 
 	$relatedquestions = qa_db_select_with_pending(
 		qa_db_search_posts_selectspec(null, qa_string_to_words($intitle), null, null, null, null, 0, false, $countqs)
@@ -56,7 +56,7 @@ if ($doexampletags) {
 	$exampletags = array();
 
 	$minweight = exp(qa_match_to_min_score(qa_opt('match_example_tags')));
-	$maxcount = qa_opt('page_size_ask_tags');
+	$maxcount = (int)qa_opt('page_size_ask_tags');
 
 	foreach ($tagweight as $tag => $weight) {
 		if ($weight < $minweight)
@@ -82,7 +82,7 @@ echo strtr(qa_html(implode(',', $exampletags)), "\r\n", '  ') . "\n";
 
 if ($doaskcheck) {
 	$minscore = qa_match_to_min_score(qa_opt('match_ask_check_qs'));
-	$maxcount = qa_opt('page_size_ask_check_qs');
+	$maxcount = (int)qa_opt('page_size_ask_check_qs');
 
 	$relatedquestions = array_slice($relatedquestions, 0, $maxcount);
 	$limitedquestions = array();

--- a/qa-include/ajax/click-pm.php
+++ b/qa-include/ajax/click-pm.php
@@ -31,7 +31,7 @@ $loginUserHandle = qa_get_logged_in_handle();
 $fromhandle = qa_post_text('handle');
 $start = (int)qa_post_text('start');
 $box = qa_post_text('box');
-$pagesize = qa_opt('page_size_pms');
+$pagesize = (int)qa_opt('page_size_pms');
 
 if (!isset($loginUserId) || $loginUserHandle !== $fromhandle || !in_array($box, array('inbox', 'outbox'))) {
 	echo "QA_AJAX_RESPONSE\n0\n";

--- a/qa-include/ajax/wallpost.php
+++ b/qa-include/ajax/wallpost.php
@@ -41,7 +41,7 @@ if ($errorhtml || !strlen($message) || !qa_check_form_security_code('wall-' . $t
 		$touseraccount['userid'], $touseraccount['handle'], $message, '');
 	$touseraccount['wallposts']++; // won't have been updated
 
-	$usermessages = qa_db_select_with_pending(qa_db_recent_messages_selectspec(null, null, $touseraccount['userid'], true, qa_opt('page_size_wall')));
+	$usermessages = qa_db_select_with_pending(qa_db_recent_messages_selectspec(null, null, $touseraccount['userid'], true, (int)qa_opt('page_size_wall')));
 	$usermessages = qa_wall_posts_add_rules($usermessages, 0);
 
 	$themeclass = qa_load_theme_class(qa_get_site_theme(), 'wall', null, null);

--- a/qa-include/pages/activity.php
+++ b/qa-include/pages/activity.php
@@ -37,7 +37,7 @@ $userid = qa_get_logged_in_userid();
 // Get lists of recent activity in all its forms, plus category information
 
 list($questions1, $questions2, $questions3, $questions4, $categories, $categoryid) = qa_db_select_with_pending(
-	qa_db_qs_selectspec($userid, 'created', 0, $categoryslugs, null, false, false, qa_opt_if_loaded('page_size_activity')),
+	qa_db_qs_selectspec($userid, 'created', 0, $categoryslugs, null, false, false, (int)qa_opt_if_loaded('page_size_activity')),
 	qa_db_recent_a_qs_selectspec($userid, 0, $categoryslugs),
 	qa_db_recent_c_qs_selectspec($userid, 0, $categoryslugs),
 	qa_db_recent_edit_qs_selectspec($userid, 0, $categoryslugs),
@@ -63,7 +63,7 @@ if ($countslugs) {
 
 return qa_q_list_page_content(
 	qa_any_sort_and_dedupe(array_merge($questions1, $questions2, $questions3, $questions4)), // questions
-	qa_opt('page_size_activity'), // questions per page
+	(int)qa_opt('page_size_activity'), // questions per page
 	0, // start offset
 	null, // total count (null to hide page links)
 	$sometitle, // title if some questions

--- a/qa-include/pages/admin/admin-approve.php
+++ b/qa-include/pages/admin/admin-approve.php
@@ -38,7 +38,7 @@ if (QA_FINAL_EXTERNAL_USERS)
 
 $userid = qa_get_logged_in_userid();
 
-$users = qa_db_get_unapproved_users(qa_opt('page_size_users'));
+$users = qa_db_get_unapproved_users((int)qa_opt('page_size_users'));
 $userfields = qa_db_select_with_pending(qa_db_userfields_selectspec());
 
 

--- a/qa-include/pages/answers.php
+++ b/qa-include/pages/answers.php
@@ -60,7 +60,7 @@ if ($countslugs) {
 
 return qa_q_list_page_content(
 	qa_any_sort_and_dedupe($questions), // questions
-	qa_opt('page_size_activity'), // questions per page
+	(int)qa_opt('page_size_activity'), // questions per page
 	0, // start offset
 	null, // total count (null to hide page links)
 	$sometitle, // title if some questions

--- a/qa-include/pages/ask.php
+++ b/qa-include/pages/ask.php
@@ -288,7 +288,7 @@ if (qa_using_tags()) {
 	);
 
 	qa_set_up_tag_field($qa_content, $field, 'tags', isset($in['tags']) ? $in['tags'] : array(), array(),
-		qa_opt('do_complete_tags') ? array_keys($completetags) : array(), qa_opt('page_size_ask_tags'));
+		qa_opt('do_complete_tags') ? array_keys($completetags) : array(), (int)qa_opt('page_size_ask_tags'));
 
 	qa_array_insert($qa_content['form']['fields'], null, array('tags' => $field));
 }

--- a/qa-include/pages/comments.php
+++ b/qa-include/pages/comments.php
@@ -59,7 +59,7 @@ if ($countslugs) {
 
 return qa_q_list_page_content(
 	qa_any_sort_and_dedupe($questions), // questions
-	qa_opt('page_size_activity'), // questions per page
+	(int)qa_opt('page_size_activity'), // questions per page
 	0, // start offset
 	null, // total count (null to hide page links)
 	$sometitle, // title if some questions

--- a/qa-include/pages/default.php
+++ b/qa-include/pages/default.php
@@ -49,7 +49,7 @@ $countslugs = count($slugs);
 $userid = qa_get_logged_in_userid();
 
 list($questions1, $questions2, $categories, $categoryid, $custompage) = qa_db_select_with_pending(
-	qa_db_qs_selectspec($userid, 'created', 0, $slugs, null, false, false, qa_opt_if_loaded('page_size_activity')),
+	qa_db_qs_selectspec($userid, 'created', 0, $slugs, null, false, false, (int)qa_opt_if_loaded('page_size_activity')),
 	qa_db_recent_a_qs_selectspec($userid, 0, $slugs),
 	qa_db_category_nav_selectspec($slugs, false, false, true),
 	$countslugs ? qa_db_slugs_to_category_id_selectspec($slugs) : null,
@@ -127,7 +127,7 @@ require_once QA_INCLUDE_DIR . 'app/q-list.php';
 
 qa_set_template('qa');
 $questions = qa_any_sort_and_dedupe(array_merge($questions1, $questions2));
-$pagesize = qa_opt('page_size_home');
+$pagesize = (int)qa_opt('page_size_home');
 
 if ($countslugs) {
 	if (!isset($categoryid)) {

--- a/qa-include/pages/favorites.php
+++ b/qa-include/pages/favorites.php
@@ -39,10 +39,9 @@ if (!isset($userid))
 
 // Get lists of favorites for this user
 
-$pagesize_qs = qa_opt('page_size_qs');
-$pagesize_users = qa_opt('page_size_users');
-$pagesize_tags = qa_opt('page_size_tags');
-
+$pagesize_qs = (int)qa_opt('page_size_qs');
+$pagesize_users = (int)qa_opt('page_size_users');
+$pagesize_tags = (int)qa_opt('page_size_tags');
 list($numQs, $questions, $numUsers, $users, $numTags, $tags, $categories) = qa_db_select_with_pending(
 	qa_db_selectspec_count(qa_db_user_favorite_qs_selectspec($userid)),
 	qa_db_user_favorite_qs_selectspec($userid, $pagesize_qs),

--- a/qa-include/pages/hot.php
+++ b/qa-include/pages/hot.php
@@ -37,7 +37,7 @@ $start = qa_get_start();
 $userid = qa_get_logged_in_userid();
 
 list($questions, $categories, $categoryid) = qa_db_select_with_pending(
-	qa_db_qs_selectspec($userid, 'hotness', $start, $categoryslugs, null, false, false, qa_opt_if_loaded('page_size_hot_qs')),
+	qa_db_qs_selectspec($userid, 'hotness', $start, $categoryslugs, null, false, false, (int)qa_opt_if_loaded('page_size_hot_qs')),
 	qa_db_category_nav_selectspec($categoryslugs, false, false, true),
 	$countslugs ? qa_db_slugs_to_category_id_selectspec($categoryslugs) : null
 );
@@ -60,7 +60,7 @@ if ($countslugs) {
 
 return qa_q_list_page_content(
 	$questions, // questions
-	qa_opt('page_size_hot_qs'), // questions per page
+	(int)qa_opt('page_size_hot_qs'), // questions per page
 	$start, // start offset
 	$countslugs ? $categories[$categoryid]['qcount'] : qa_opt('cache_qcount'), // total count
 	$sometitle, // title if some questions

--- a/qa-include/pages/messages.php
+++ b/qa-include/pages/messages.php
@@ -59,7 +59,7 @@ if (!qa_opt('allow_private_messages') || !qa_opt('show_message_history'))
 // Find the messages for this user
 
 $start = qa_get_start();
-$pagesize = qa_opt('page_size_pms');
+$pagesize = (int)qa_opt('page_size_pms');
 
 // get number of messages then actual messages for this page
 $func = $showOutbox ? 'qa_db_messages_outbox_selectspec' : 'qa_db_messages_inbox_selectspec';

--- a/qa-include/pages/question-post.php
+++ b/qa-include/pages/question-post.php
@@ -386,7 +386,7 @@ function qa_page_q_edit_q_form(&$qa_content, $question, $in, $errors, $completet
 
 	if (qa_using_tags() && $question['retagcatable']) {
 		qa_set_up_tag_field($qa_content, $form['fields']['tags'], 'q_tags', isset($in['tags']) ? $in['tags'] : qa_tagstring_to_tags($question['tags']),
-			array(), $completetags, qa_opt('page_size_ask_tags'));
+			array(), $completetags, (int)qa_opt('page_size_ask_tags'));
 	} else {
 		unset($form['fields']['tags']);
 	}

--- a/qa-include/pages/question.php
+++ b/qa-include/pages/question.php
@@ -364,7 +364,7 @@ asort($answerposition, SORT_NUMERIC);
 
 $answerids = array_keys($answerposition);
 $countforpages = count($answerids);
-$pagesize = qa_opt('page_size_q_as');
+$pagesize = (int)qa_opt('page_size_q_as');
 
 // see if we need to display a particular answer
 

--- a/qa-include/pages/questions.php
+++ b/qa-include/pages/questions.php
@@ -114,7 +114,7 @@ switch ($sort) {
 
 $qa_content = qa_q_list_page_content(
 	$questions, // questions
-	qa_opt('page_size_qs'), // questions per page
+	(int)qa_opt('page_size_qs'), // questions per page
 	$start, // start offset
 	$countslugs ? $categories[$categoryid]['qcount'] : qa_opt('cache_qcount'), // total count
 	$sometitle, // title if some questions

--- a/qa-include/pages/search.php
+++ b/qa-include/pages/search.php
@@ -37,7 +37,7 @@ if (strlen(qa_get('q'))) {
 	$userid = qa_get_logged_in_userid();
 	$start = qa_get_start();
 
-	$display = qa_opt_if_loaded('page_size_search');
+	$display = (int)qa_opt_if_loaded('page_size_search');
 	$count = 2 * (isset($display) ? $display : QA_DB_RETRIEVE_QS_AS) + 1;
 	// get enough results to be able to give some idea of how many pages of search results there are
 
@@ -47,7 +47,7 @@ if (strlen(qa_get('q'))) {
 
 	// Count and truncate results
 
-	$pagesize = qa_opt('page_size_search');
+	$pagesize = (int)qa_opt('page_size_search');
 	$gotcount = count($results);
 	$results = array_slice($results, 0, $pagesize);
 

--- a/qa-include/pages/tag.php
+++ b/qa-include/pages/tag.php
@@ -44,7 +44,7 @@ list($questions, $tagword) = qa_db_select_with_pending(
 	qa_db_tag_word_selectspec($tag)
 );
 
-$pagesize = qa_opt('page_size_tag_qs');
+$pagesize = (int)qa_opt('page_size_tag_qs');
 $questions = array_slice($questions, 0, $pagesize);
 $usershtml = qa_userids_handles_html($questions);
 

--- a/qa-include/pages/tags.php
+++ b/qa-include/pages/tags.php
@@ -33,11 +33,11 @@ require_once QA_INCLUDE_DIR . 'app/format.php';
 $start = qa_get_start();
 $userid = qa_get_logged_in_userid();
 $populartags = qa_db_select_with_pending(
-	qa_db_popular_tags_selectspec($start, qa_opt_if_loaded('page_size_tags'))
+	qa_db_popular_tags_selectspec($start, (int)qa_opt_if_loaded('page_size_tags'))
 );
 
-$tagcount = qa_opt('cache_tagcount');
-$pagesize = qa_opt('page_size_tags');
+$tagcount = (int)qa_opt('cache_tagcount');
+$pagesize = (int)qa_opt('page_size_tags');
 
 
 // Prepare content for theme

--- a/qa-include/pages/unanswered.php
+++ b/qa-include/pages/unanswered.php
@@ -56,7 +56,7 @@ switch ($by) {
 }
 
 list($questions, $categories, $categoryid) = qa_db_select_with_pending(
-	qa_db_unanswered_qs_selectspec($userid, $selectby, $start, $categoryslugs, false, false, qa_opt_if_loaded('page_size_una_qs')),
+	qa_db_unanswered_qs_selectspec($userid, $selectby, $start, $categoryslugs, false, false, (int)qa_opt_if_loaded('page_size_una_qs')),
 	QA_ALLOW_UNINDEXED_QUERIES ? qa_db_category_nav_selectspec($categoryslugs, false, false, true) : null,
 	$countslugs ? qa_db_slugs_to_category_id_selectspec($categoryslugs) : null
 );
@@ -117,7 +117,7 @@ switch ($by) {
 
 $qa_content = qa_q_list_page_content(
 	$questions, // questions
-	qa_opt('page_size_una_qs'), // questions per page
+	(int)qa_opt('page_size_una_qs'), // questions per page
 	$start, // start offset
 	@$count, // total count
 	$sometitle, // title if some questions

--- a/qa-include/plugins/qa-widget-related-qs.php
+++ b/qa-include/plugins/qa-widget-related-qs.php
@@ -43,7 +43,7 @@ class qa_related_qs
 		$userid = qa_get_logged_in_userid();
 		$cookieid = qa_cookie_get();
 
-		$questions = qa_db_single_select(qa_db_related_qs_selectspec($userid, $questionid, qa_opt('page_size_related_qs')));
+		$questions = qa_db_single_select(qa_db_related_qs_selectspec($userid, $questionid, (int)qa_opt('page_size_related_qs')));
 
 		$minscore = qa_match_to_min_score(qa_opt('match_related_qs'));
 

--- a/qa-src/Controllers/User/UserMessages.php
+++ b/qa-src/Controllers/User/UserMessages.php
@@ -49,7 +49,7 @@ class UserMessages extends \Q2A\Controllers\BaseController
 
 		list($useraccount, $usermessages) = qa_db_select_with_pending(
 			qa_db_user_account_selectspec($handle, false),
-			qa_db_recent_messages_selectspec(null, null, $handle, false, qa_opt_if_loaded('page_size_wall'), $start)
+			qa_db_recent_messages_selectspec(null, null, $handle, false, (int)qa_opt_if_loaded('page_size_wall'), $start)
 		);
 		if (!is_array($useraccount)) { // check the user exists
 			throw new PageNotFoundException();
@@ -57,7 +57,7 @@ class UserMessages extends \Q2A\Controllers\BaseController
 
 		// Perform pagination
 
-		$pagesize = qa_opt('page_size_wall');
+		$pagesize = (int)qa_opt('page_size_wall');
 		$count = $useraccount['wallposts'];
 		$loginuserid = qa_get_logged_in_userid();
 

--- a/qa-src/Controllers/User/UserPosts.php
+++ b/qa-src/Controllers/User/UserPosts.php
@@ -50,7 +50,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 
 		list($useraccount, $questions, $answerqs, $commentqs, $editqs) = qa_db_select_with_pending(
 			QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
-			qa_db_user_recent_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_activity')),
+			qa_db_user_recent_qs_selectspec($loginuserid, $identifier, (int)qa_opt_if_loaded('page_size_activity')),
 			qa_db_user_recent_a_qs_selectspec($loginuserid, $identifier),
 			qa_db_user_recent_c_qs_selectspec($loginuserid, $identifier),
 			qa_db_user_recent_edit_qs_selectspec($loginuserid, $identifier)
@@ -62,7 +62,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 		// Get information on user references
 
 		$questions = qa_any_sort_and_dedupe(array_merge($questions, $answerqs, $commentqs, $editqs));
-		$questions = array_slice($questions, 0, qa_opt('page_size_activity'));
+		$questions = array_slice($questions, 0, (int)qa_opt('page_size_activity'));
 		$usershtml = qa_userids_handles_html(qa_any_get_userids_handles($questions), false);
 
 
@@ -135,7 +135,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 		list($useraccount, $userpoints, $questions) = qa_db_select_with_pending(
 			QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
 			qa_db_user_points_selectspec($identifier),
-			qa_db_user_recent_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_qs'), $start)
+			qa_db_user_recent_qs_selectspec($loginuserid, $identifier, (int)qa_opt_if_loaded('page_size_qs'), $start)
 		);
 
 		if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) { // check the user exists
@@ -145,7 +145,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 
 		// Get information on user questions
 
-		$pagesize = qa_opt('page_size_qs');
+		$pagesize = (int)qa_opt('page_size_qs');
 		$count = (int)@$userpoints['qposts'];
 		$questions = array_slice($questions, 0, $pagesize);
 		$usershtml = qa_userids_handles_html($questions, false);
@@ -222,7 +222,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 		list($useraccount, $userpoints, $questions) = qa_db_select_with_pending(
 			QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
 			qa_db_user_points_selectspec($identifier),
-			qa_db_user_recent_a_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_activity'), $start)
+			qa_db_user_recent_a_qs_selectspec($loginuserid, $identifier, (int)qa_opt_if_loaded('page_size_activity'), $start)
 		);
 
 		if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) { // check the user exists
@@ -232,7 +232,7 @@ class UserPosts extends \Q2A\Controllers\BaseController
 
 		// Get information on user questions
 
-		$pagesize = qa_opt('page_size_activity');
+		$pagesize = (int)qa_opt('page_size_activity');
 		$count = (int)@$userpoints['aposts'];
 		$questions = array_slice($questions, 0, $pagesize);
 		$usershtml = qa_userids_handles_html($questions, false);

--- a/qa-src/Controllers/User/UserProfile.php
+++ b/qa-src/Controllers/User/UserProfile.php
@@ -73,7 +73,7 @@ class UserProfile extends \Q2A\Controllers\BaseController
 				QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
 				QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_profile_selectspec($handle, false),
 				QA_FINAL_EXTERNAL_USERS ? null : qa_db_userfields_selectspec(),
-				QA_FINAL_EXTERNAL_USERS ? null : qa_db_recent_messages_selectspec(null, null, $handle, false, qa_opt_if_loaded('page_size_wall')),
+				QA_FINAL_EXTERNAL_USERS ? null : qa_db_recent_messages_selectspec(null, null, $handle, false, (int)qa_opt_if_loaded('page_size_wall')),
 				qa_db_user_points_selectspec($identifier),
 				qa_db_user_levels_selectspec($identifier, QA_FINAL_EXTERNAL_USERS, true),
 				qa_db_category_nav_selectspec(null, true),
@@ -146,7 +146,7 @@ class UserProfile extends \Q2A\Controllers\BaseController
 
 			// This code is similar but not identical to that in to qq-page-user-wall.php
 
-			$usermessages = array_slice($usermessages, 0, qa_opt('page_size_wall'));
+			$usermessages = array_slice($usermessages, 0, (int)qa_opt('page_size_wall'));
 			$usermessages = qa_wall_posts_add_rules($usermessages, 0);
 
 			foreach ($usermessages as $message) {

--- a/qa-src/Controllers/User/UsersList.php
+++ b/qa-src/Controllers/User/UsersList.php
@@ -175,7 +175,7 @@ class UsersList extends \Q2A\Controllers\BaseController
 
 		$request = qa_request();
 		$start = qa_get_start();
-		$pageSize = qa_opt('page_size_users');
+		$pageSize = (int)qa_opt('page_size_users');
 
 		list($totalUsers, $users) = $fnUsersAndCount($start, $pageSize);
 


### PR DESCRIPTION
These are all related to the `qa_opt()` function returning strings and the new DB handling approach expects integers to actually be integers.

Although this could be fixed inside each of the functions, if the PHPDocs state a function receives an int, it should be an int. That's why I believe the casting should be done outside and, of course, to avoid adding so much _defensive code_.