### PR TITLE
Avoid checking for plugin updates in each page refresh

### DIFF
--- a/qa-content/qa-admin.js
+++ b/qa-content/qa-admin.js
@@ -148,6 +148,13 @@ function qa_version_check(uri, version, elem, isCore)
 	);
 }
 
+function qa_version_check_array(versionChecks)
+{
+	for (var i = 0; i < versionChecks.length; i++) {
+		qa_version_check(versionChecks[i].uri, versionChecks[i].version, versionChecks[i].elem, false)
+	}
+}
+
 function qa_get_enabled_plugins_hashes()
 {
 	var hashes = [];

--- a/qa-include/Q2A/Plugin/PluginManager.php
+++ b/qa-include/Q2A/Plugin/PluginManager.php
@@ -25,6 +25,8 @@ class Q2A_Plugin_PluginManager
 {
 	const PLUGIN_DELIMITER = ';';
 	const OPT_ENABLED_PLUGINS = 'enabled_plugins';
+	const OPT_LAST_UPDATE_CHECK = 'last_plugin_update_check';
+	const NUMBER_OF_DAYS_TO_CHECK_FOR_UPDATE = 14;
 
 	private $loadBeforeDbInit = array();
 	private $loadAfterDbInit = array();
@@ -179,5 +181,28 @@ class Q2A_Plugin_PluginManager
 		);
 
 		$this->setEnabledPluginsOption($finalEnabledPlugins);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function shouldCheckForUpdate()
+	{
+		$lastUpdateCheck = (int)qa_opt(self::OPT_LAST_UPDATE_CHECK);
+		$currentTime = (int)qa_opt('db_time');
+
+		return $currentTime - $lastUpdateCheck > self::NUMBER_OF_DAYS_TO_CHECK_FOR_UPDATE * 24 * 60 * 60;
+	}
+
+	/**
+	 * @param int|null $time
+	 */
+	public function performUpdateCheck($time = null)
+	{
+		if ($time === null) {
+			$time = time();
+		}
+
+		qa_opt(self::OPT_LAST_UPDATE_CHECK, $time);
 	}
 }

--- a/qa-include/lang/qa-lang-admin.php
+++ b/qa-include/lang/qa-lang-admin.php
@@ -273,6 +273,7 @@ return array(
 	'users_registered' => 'Registered users:',
 	'users_title' => 'Users',
 	'users_voted' => 'Users who voted:',
+	'version_check' => 'Check for updates',
 	'version_get_x' => 'get ^',
 	'version_latest' => 'latest',
 	'version_latest_unknown' => 'latest unknown',


### PR DESCRIPTION
I'm sending this to the bugfix branch as it is a minor feature that doesn't really need to wait for 1.9 and could serve as an excuse to release a new patch version soon.