### PR TITLE
Get proper client IP. Checking proxy instead

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1260,8 +1260,17 @@ function qa_clicked($name)
 function qa_remote_ip_address()
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
-
-	return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null;
+	
+	if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
+		$parsedUrl = parse_url($_SERVER["HTTP_X_FORWARDED_FOR"]);
+		return $parsedUrl['host'];
+	} else if (array_key_exists('REMOTE_ADDR', $_SERVER)) {
+		return $_SERVER["REMOTE_ADDR"];
+	} else if (array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
+		return $_SERVER["HTTP_CLIENT_IP"];
+	} else {
+		return null;
+	}
 }
 
 

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1260,13 +1260,13 @@ function qa_clicked($name)
 function qa_remote_ip_address()
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
-	
+
 	if (array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
 		$parsedUrl = parse_url($_SERVER["HTTP_X_FORWARDED_FOR"]);
 		return $parsedUrl['host'];
-	} else if (array_key_exists('REMOTE_ADDR', $_SERVER)) {
+	} elseif (array_key_exists('REMOTE_ADDR', $_SERVER)) {
 		return $_SERVER["REMOTE_ADDR"];
-	} else if (array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
+	} elseif (array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
 		return $_SERVER["HTTP_CLIENT_IP"];
 	} else {
 		return null;


### PR DESCRIPTION
I am checking if the HTTP_X_FORWARDED_FOR to get the client ip.
https://en.wikipedia.org/wiki/X-Forwarded-For

My Q2A did not count the number of visits properly with proxy enabled.