### PR TITLE
Add docker, docker stack and helm deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,15 @@ Official releases can be found either on the [Q2A website][Q2A] or via the Relea
 [6]: https://docs.question2answer.org/themes/
 [7]: https://docs.question2answer.org/translate/
 [8]: https://docs.question2answer.org/addons/
+
+## Deployment
+
+Docker, Docker Stack and Kubernetes
+-----------------------------------
+
+For instructions look at the deployment folder [README.md](deployment/README.md).
+
+In an already running server
+----------------------------
+
+Look at https://docs.question2answer.org/install/ for instructions.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,102 @@
+# Deployment
+
+## The Docker image
+Inside the `docker` folder you'll find a Dockerfile based on php-fpm that
+will download and store the question2answer source code. The q2a version can
+be modified by passing the `Q2A_VERSION` argument at build time:
+
+    cd docker/
+    docker build . --build-arg Q2A_VERSION=1.7.5 --tag q2a
+
+
+### Environment variables
+There are several environment variables you need to set in order to deploy the
+Docker image. Also there are others you can use in your scripts that are
+declared on runtime or inherited from buildtime.
+
+#### Required variables
+You must declare the following variables to run the image:
+- **QA_DB_HOSTNAME**: MySQL hostname.
+- **QA_DB_USER**: MySQL username for q2a.
+- **QA_DB_PASS**: MySQL q2a user password.
+- **QA_DB_NAME**: MySQL database for q2a.
+
+#### Optional variables
+- **ROOT**: This is the root directory where the application files (not only
+  the q2a ones) will be stored. This directory should be shared with NGINX or
+  any software used to serve the site files.
+- **Q2A_DIR_NAME**: This is the name that will be used for the q2a application
+  folder located at `$ROOT`. The source files will be copied here in order to be
+  served.
+
+#### Runtime variables
+- **Q2A_DIR**: This is the absolute path to the q2a source code. It is defined
+  as `Q2A_DIR=${ROOT}/${Q2A_DIR_NAME}`.
+
+
+### Initializing a fresh instance
+This container support initialization scripts which may be mounted as `.sh`
+files with execution permissions at:
+
+    /docker-entrypoint-init.d/
+
+these scripts could be used to install plugins, themes or configure the running
+instance. Look at the provisioning [README.rst](provisioning/q2a/README.rst)
+for an example of one script.
+
+
+## The "provisioning" directories
+At the root of the `deployment` folder you will find a `provisioning` directory
+that is shared by symbolink links between the docker and helm directories. The
+files in this folder will be mount in the containers initialization path to
+provision them when the containers start. For more information look at the
+`README.rst` files inside the provisioning folders.
+
+
+## Docker stack
+The `docker` folder contains a compose file which enables the possibility to
+deploy an instance of question2answers using docker stack.
+
+### Setting up a stack
+Modify the `stack.yaml` with your own values. Set the q2a and mysql environment
+variables with your own username, password and database name. Look for the
+`__change_me__` hints to find easily what must be replaced. You can also tweak
+any other attribute if you want, as the image versions or network ports.
+
+To run an instance `docker stack` must be configured in your computer.
+
+Deploy the stack using:
+
+    cd docker/
+    docker stack deploy -c stack.yaml q2a
+
+this will run a q2a, mysql, and nginx containers that serve q2a on the url:
+
+    http://localhost:8000
+
+If you have any trouble accessing it, you can also look to the stack status and
+services logs in order to figure out what is going on:
+
+    docker stack ps q2a  # use the --no-trunc option for more information
+    docker services q2a_<service> logs  # change the service for q2a, mysql or nginx
+
+
+## Helm
+
+There is a helm chart to deploy question2answers in kubernetes. For this, a
+public image of the Dockerfile is needed but for now, there is none published;
+so you may have to publish your own until an official one is released.
+
+The chart provides a way to deploy a q2a instance, among with a MySQL database
+and a NGINX reverse proxy to serve the site files.
+
+Before deploying your instance of q2a, edit the `values.yaml` file at the helm
+directory for your needs, and set your own values for the database name, user
+and passwords. Look for the `__change_me__` hints to find easily what must be
+replaced. There is also an optional ingress that can be activated for
+http or https.
+
+To deploy an instance of the q2a chart, run:
+
+    cd helm
+    helm install . -f values.yaml -n <release_name> --namespace <namespace>

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:7.3.11-fpm
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Setup and install base system software
+RUN echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections \
+    && echo "locales locales/default_environment_locale select en_US.UTF-8" | debconf-set-selections \
+    && apt-get update && apt-get --yes --no-install-recommends install \
+        locales ca-certificates curl vim nano unzip tar tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure php and install extensions
+RUN mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" \
+    && docker-php-ext-install mysqli
+
+# Get q2a
+ENV SRC_DIR /opt/q2a/src/
+WORKDIR /opt/q2a/
+
+ARG Q2A_VERSION="1.8.3"
+ENV Q2A_FILE_NAME "question2answer-${Q2A_VERSION}"
+ENV Q2A_DOWNLOAD_URL "https://github.com/q2a/question2answer/releases/download/v${Q2A_VERSION}/${Q2A_FILE_NAME}.zip"
+
+RUN curl -L ${Q2A_DOWNLOAD_URL} --output ${Q2A_FILE_NAME}.zip \
+    && unzip ${Q2A_FILE_NAME}.zip \
+    && rm ${Q2A_FILE_NAME}.zip \
+    && mv ${Q2A_FILE_NAME} src
+
+COPY files/qa-entrypoint.sh /usr/local/bin/qa-entrypoint
+ENTRYPOINT ["qa-entrypoint"]

--- a/deployment/docker/files/qa-entrypoint.sh
+++ b/deployment/docker/files/qa-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+# Environment variables explanation:
+
+# ROOT: This is the root directory where the application files (not only the
+# q2a ones) will be stored. This directory should be shared with NGINX or any
+# software used to serve the site files.
+
+# Q2A_DIR_NAME: This is the name that will be used for the q2a application
+# folder located at $ROOT. The source files will be copied here in order to
+# be served.
+
+# Q2A_DIR: This is the absolute path to the folder were q2a will be served.
+
+ROOT=${ROOT:-/var/www/html/}
+Q2A_DIR_NAME=${Q2A_DIR_NAME:-q2a}
+export Q2A_DIR=${ROOT}${Q2A_DIR_NAME}
+
+# The SRC_DIR variable is set at the Dockerfile, and contains the location
+# where the source code was downloaded to the image at build time. This source
+# code will be copied to the Q2A_DIR which is the folder from where the
+# application will be served.
+# The copy is required to support a shared folder with the site data between
+# this container and another application (i.e. NGINX) that serves the files.
+# The SRC_DIR is not used for sharing purposes because some container platforms
+# (as kubernetes), don't keep the files of a directory when a shared volume is
+# mount at the same path.
+SRC_DIR=${SRC_DIR:-"/opt/q2a/src"}
+echo "Populating Q2A directory"
+mkdir -p ${Q2A_DIR}
+cp -r ${SRC_DIR}/* ${Q2A_DIR}
+
+# Set the config file if not present
+Q2A_CONFIG=qa-config.php
+if [ ! -f "$Q2A_CONFIG" ]; then
+    echo "Configuring Q2A"
+    pushd ${Q2A_DIR}
+    mv qa-config-example.php ${Q2A_CONFIG}
+    sed -i -e "s/127.0.0.1/${QA_DB_HOSTNAME}/g" ${Q2A_CONFIG}
+    sed -i -e "s/your-mysql-username/${QA_DB_USER}/g" ${Q2A_CONFIG}
+    sed -i -e "s/your-mysql-password/${QA_DB_PASS}/g" ${Q2A_CONFIG}
+    sed -i -e "s/your-mysql-db-name/${QA_DB_NAME}/g"  ${Q2A_CONFIG}
+    popd
+fi
+
+# Run initialization scripts
+echo "Running initialization scripts"
+for f in /docker-entrypoint-init.d/*; do
+    # Check if executable
+    if [ ! -x "$f" ]; then
+        continue
+    fi
+    case "$f" in
+        *.sh) echo "$0: running $f"; . "$f" ;;
+        *)    echo "$0: ignoring $f" ;;
+    esac
+    echo
+done
+
+# Run php-fpm
+php-fpm &
+pid=$!
+echo "php-fpm PID: ${pid}."
+
+# Cleaning
+unset SRC_DIR
+unset QA_DB_HOSTNAME
+unset QA_DB_USER
+unset QA_DB_PASS
+unset QA_DB_NAME
+unset ROOT
+unset Q2A_DIR_NAME
+
+history -c
+history -w
+
+# Run any user command
+
+if [ ! -z ${@+x} ]; then
+    echo "Running user command : $@"
+    exec "$@"
+else
+    # Wait the service
+    echo 'Waiting until php-fpm termination.'
+    wait $pid
+fi

--- a/deployment/docker/nginx/nginx.conf
+++ b/deployment/docker/nginx/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html/q2a/;
+    index index.php;
+    autoindex off;
+
+    location ~* \.php$ {
+        fastcgi_pass    q2a:9000;
+        include         fastcgi_params;
+        fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+        fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
+        fastcgi_index   index.php;
+    }
+}

--- a/deployment/docker/provisioning
+++ b/deployment/docker/provisioning
@@ -1,0 +1,1 @@
+../provisioning/

--- a/deployment/docker/stack.yaml
+++ b/deployment/docker/stack.yaml
@@ -1,0 +1,49 @@
+version: '3'
+services:
+
+  q2a:
+    image: q2a:latest
+    deploy:
+      restart_policy:
+        delay: 10s
+        max_attempts: 12
+    environment:
+      - QA_DB_HOSTNAME=mysql
+      - QA_DB_USER=__change_me__
+      - QA_DB_PASS=__change_me__
+      - QA_DB_NAME=__change_me__
+    volumes:
+      - &html html:/var/www/html
+      - ./provisioning/q2a/:/docker-entrypoint-init.d
+
+  mysql:
+    image: mysql:8.0.18
+    deploy:
+      restart_policy:
+        delay: 5s
+        max_attempts: 4
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      - MYSQL_ROOT_PASSWORD=__change_me__
+      - MYSQL_USER=__change_me__
+      - MYSQL_PASSWORD=__change_me__
+      - MYSQL_DATABASE=__change_me__
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./provisioning/mysql/:/docker-entrypoint-initdb.d
+
+  nginx:
+    image: nginx:1.17.5-alpine
+    deploy:
+      restart_policy:
+        delay: 10s
+        max_attempts: 4
+    volumes:
+      - ./nginx/:/etc/nginx/conf.d/
+      - *html
+    ports:
+      - 8000:80
+
+volumes:
+  db_data:
+  html:

--- a/deployment/helm/.helmignore
+++ b/deployment/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: q2a
+version: 0.1.0

--- a/deployment/helm/provisioning
+++ b/deployment/helm/provisioning
@@ -1,0 +1,1 @@
+../provisioning/

--- a/deployment/helm/templates/NOTES.txt
+++ b/deployment/helm/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "q2a.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "q2a.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "q2a.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deployment/helm/templates/_services.tpl
+++ b/deployment/helm/templates/_services.tpl
@@ -1,0 +1,20 @@
+{{/*
+MySQL service subdomain name
+*/}}
+{{- define "q2a.mysql-service-name" -}}
+{{ include "q2a.fullname" . }}-mysql
+{{- end -}}
+
+{{/*
+NGINX service subdomain name
+*/}}
+{{- define "q2a.nginx-service-name" -}}
+{{ include "q2a.fullname" . }}-nginx
+{{- end -}}
+
+{{/*
+Q2A service subdomain name
+*/}}
+{{- define "q2a.q2a-service-name" -}}
+{{ include "q2a.fullname" . }}-q2a
+{{- end -}}

--- a/deployment/helm/templates/_shared.tpl
+++ b/deployment/helm/templates/_shared.tpl
@@ -1,0 +1,24 @@
+{{/*
+Q2A Directory
+*/}}
+{{- define "q2a.q2a-dir" -}}
+{{ printf "%s/q2a/" .Values.nginx.root | clean }}
+{{- end -}}
+
+{{/*
+NGINX and Q2A will share the following volume mounts
+*/}}
+{{- define "q2a.shared-volume-mounts" -}}
+- name: q2a-data
+  mountPath: {{ include "q2a.q2a-dir" . }}
+{{- end -}}
+
+{{/*
+NGINX and Q2A will share the following volumes
+*/}}
+{{- define "q2a.q2a-shared-volumes" -}}
+- name: q2a-data
+  persistentVolumeClaim:
+    claimName: {{ include "q2a.fullname" . }}-q2a-data
+{{- end -}}
+

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "q2a.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.ingress.annotations -}}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.tls.host }}
+      secretName: {{ include "q2a.fullname" . }}-tls-certs
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ include "q2a.nginx-service-name" . }}
+              servicePort: {{ .Values.nginx.service.port }}
+
+---
+{{- if .Values.ingress.tls.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "q2a.fullname" . }}-tls-certs
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  tls.crt: {{ .Values.ingress.tls.crt | b64enc }}
+  tls.key: {{ .Values.ingress.tls.key | b64enc }}
+{{- end }}
+
+{{- end }}

--- a/deployment/helm/templates/mysql.yaml
+++ b/deployment/helm/templates/mysql.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "q2a.fullname" . }}-mysql
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+      app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+        app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-mysql
+          image: "{{ .Values.mysql.image.address }}"
+          args: ["--default-authentication-plugin=mysql_native_password"]
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+            - name: mysql-init
+              mountPath: /docker-entrypoint-initdb.d
+          ports:
+            - name: mysql
+              containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: {{ .Values.mysql.auth.root_password }}
+            - name: MYSQL_USER
+              value: {{ .Values.mysql.auth.user }}
+            - name: MYSQL_PASSWORD
+              value: {{ .Values.mysql.auth.user_password }}
+            - name: MYSQL_DATABASE
+              value: {{ .Values.mysql.database_name }}
+            {{ if .Values.mysql.env -}}
+            {{- toYaml .Values.mysql.env | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: mysql-data
+          persistentVolumeClaim:
+            claimName: {{ include "q2a.fullname" . }}-mysql
+        - name: mysql-init
+          configMap:
+            name: {{ include "q2a.fullname" . }}-mysql-init
+            defaultMode: 0755
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.mysql-service-name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: database
+spec:
+  ports:
+    - name: mysql
+      port: {{ .Values.mysql.service.port }}
+      targetPort: mysql
+  selector:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+    app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "q2a.fullname" . }}-mysql
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-mysql
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-mysql
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: database
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.mysql.volume.size }}
+  {{- if .Values.mysql.volume.storage_class }}
+  storageClassName: {{ .Values.mysql.volume.storage_class }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.fullname" . }}-mysql-init
+data:
+  {{- ($.Files.Glob "provisioning/mysql/*").AsConfig | nindent 2 }}

--- a/deployment/helm/templates/nginx.yaml
+++ b/deployment/helm/templates/nginx.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "q2a.fullname" . }}-nginx
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-nginx
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nginx.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "q2a.name" . }}-nginx
+      app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "q2a.name" . }}-nginx
+        app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-nginx
+          image: "{{ .Values.nginx.image.address }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          volumeMounts:
+            {{ include "q2a.shared-volume-mounts" . | nindent 12 }}
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginx.port }}
+              protocol: TCP
+          env:
+            {{ if .Values.nginx.env -}}
+            {{- toYaml .Values.nginx.env | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{ include "q2a.q2a-shared-volumes" . | nindent 8 }}
+        - name: nginx-conf
+          configMap:
+            name: {{ include "q2a.fullname" . }}-nginx-conf
+            defaultMode: 0755
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.nginx-service-name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-nginx
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: reverse-proxy
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.nginx.service.port }}
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-nginx
+    app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.fullname" . }}-nginx-conf
+data:
+  nginx.conf: |
+    server {
+        listen {{ .Values.nginx.port }};
+        server_name localhost;
+        root {{ include "q2a.q2a-dir" . }};
+        index index.php;
+        autoindex off;
+
+        location ~* \.php$ {
+            fastcgi_pass    {{ include "q2a.q2a-service-name" . }}:{{ .Values.q2a.php_fpm_port }};
+            include         fastcgi_params;
+            fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+            fastcgi_param   SCRIPT_NAME        $fastcgi_script_name;
+            fastcgi_index   index.php;
+        }
+    }

--- a/deployment/helm/templates/q2a.yaml
+++ b/deployment/helm/templates/q2a.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "q2a.fullname" . }}-q2a
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-q2a
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.q2a.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a
+      app.kubernetes.io/instance: {{ .Release.Name }}-q2a
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a
+        app.kubernetes.io/instance: {{ .Release.Name }}-q2a
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-q2a
+          image: "{{ .Values.q2a.image.address }}"
+          imagePullPolicy: {{ .Values.q2a.image.pullPolicy }}
+          volumeMounts:
+            {{- include "q2a.shared-volume-mounts" . | nindent 12 }}
+            - name: q2a-init
+              mountPath: /docker-entrypoint-init.d
+          ports:
+            - name: php-fpm
+              containerPort: {{ .Values.q2a.php_fpm_port }}
+              protocol: TCP
+          env:
+            - name: QA_DB_HOSTNAME
+              value: {{ include "q2a.mysql-service-name" . }}
+            - name: QA_DB_USER
+              value: {{ .Values.mysql.auth.user }}
+            - name: QA_DB_PASS
+              value: {{ .Values.mysql.auth.user_password }}
+            - name: QA_DB_NAME
+              value: {{ .Values.mysql.database_name }}
+            {{ if .Values.q2a.env -}}
+            {{- toYaml .Values.q2a.env | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- include "q2a.q2a-shared-volumes" . | nindent 8 }}
+        - name: q2a-init
+          configMap:
+            name: {{ include "q2a.fullname" . }}-q2a-init
+            defaultMode: 0755
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.q2a-service-name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-q2a
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: server
+spec:
+  ports:
+    - name: php-fpm
+      port: {{ .Values.q2a.service.port }}
+      targetPort: php-fpm
+  selector:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a
+    app.kubernetes.io/instance: {{ .Release.Name }}-q2a
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace}}
+  name: {{ include "q2a.fullname" . }}-q2a-init
+data:
+  {{- ($.Files.Glob "provisioning/q2a/*").AsConfig | nindent 2 }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "q2a.fullname" . }}-q2a-data
+  labels:
+    app.kubernetes.io/name: {{ include "q2a.name" . }}-q2a-data
+    helm.sh/chart: {{ include "q2a.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}-q2a-data
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: q2a
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.q2a.volume.size }}
+  {{- if .Values.q2a.volume.storage_class }}
+  storageClassName: {{ .Values.q2a.volume.storage_class }}
+  {{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -1,0 +1,97 @@
+# Default values for q2a.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+q2a:
+  replicas: 1
+  image:
+    address: # for now, you need to build and publish your own image
+    pullPolicy: Always
+  # php_fpm_port is the port where the php-fpm service is listening in the
+  # container
+  php_fpm_port: 9000
+  service:
+    # the port where the service will listen
+    port: 9000
+  volume:
+    size: 1Gi
+    storage_class:
+  env:
+    # declare env variables with the kubernetes format, i.e.:
+    # - name: http_proxy
+    #   value:
+
+nginx:
+  replicas: 1
+  image:
+    address: nginx:1.17.5-alpine
+    pullPolicy: IfNotPresent
+  # root is the directory from where nginx will serve the data
+  root: /var/www/html/
+  # the port where nginx will be listening. Don't confuse this port with the
+  # ingress port. This is for an internal reverse proxy used to serve the files
+  # and connect with the php server.
+  port: 80
+  service:
+    # the port where the service will listen
+    port: 80
+  env:
+    # declare env variables with the kubernetes format, i.e.:
+    # - name: http_proxy
+    #   value:
+
+mysql:
+  image:
+    address: mysql:8.0.18
+    pullPolicy: IfNotPresent
+  service:
+    # the port where the service will listen
+    port: 3306
+  database_name: __change_me__
+  auth:
+    root_password: __change_me__
+    user: __change_me__
+    user_password: __change_me__
+  volume:
+    size: 1Gi
+    storage_class:
+  env:
+    # declare env variables with the kubernetes format, i.e.:
+    # - name: http_proxy
+    #   value:
+
+ingress:
+  enabled: false
+  # this annotations will be added to the ingress file
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  path: /
+  host: <your.host.url>
+  tls:
+    enabled: false
+    host: <your.host.url>
+    crt: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deployment/provisioning/mysql/README.rst
+++ b/deployment/provisioning/mysql/README.rst
@@ -1,0 +1,14 @@
+Provisioning scripts
+====================
+
+These scripts are mounted to /docker-entrypoint-initdb.d and are run by the
+MySQL entrypoint as described in:
+
+    https://hub.docker.com/_/mysql section "Initializing a fresh instance"
+
+And implemented here:
+
+    https://github.com/mysql/mysql-docker/blob/mysql-server/5.7/docker-entrypoint.sh#L149
+
+Use the .sh script to run commands that use environment variables and .sql to
+run MySQL commnads.

--- a/deployment/provisioning/q2a/README.rst
+++ b/deployment/provisioning/q2a/README.rst
@@ -1,0 +1,67 @@
+Provisioning scripts
+====================
+
+These scripts are mounted to `/docker-entrypoint-init.d` and are run by the
+Q2A entrypoint. These files must be:
+
+- scripts with the .sh extension
+- executables
+
+Use the scripts to install plugins, themes or configure your system. For example:
+
+.. code-block:: bash
+
+    #!/usr/bin/env bash
+
+    set -o errexit
+    set -o nounset
+
+    pushd /tmp
+
+    ###################
+    # Install plugins #
+    ###################
+
+    echo "Installing plugins..."
+
+    # Markdown Editor
+    # ---------------
+
+    PLUGIN_NAME=q2a-markdown-editor
+    PLUGIN_VERSION=2.6.0
+    PLUGIN_FILE_NAME=${PLUGIN_NAME}-${PLUGIN_VERSION}
+
+    curl -L "https://github.com/svivian/q2a-markdown-editor/archive/v${PLUGIN_VERSION}.zip" --output ${PLUGIN_FILE_NAME}.zip
+    unzip ${PLUGIN_FILE_NAME}.zip
+    rm ${PLUGIN_FILE_NAME}.zip
+    cp -r ${PLUGIN_FILE_NAME} ${Q2A_DIR}/qa-plugin/${PLUGIN_NAME}
+    rm -rf ${PLUGIN_FILE_NAME}
+
+    echo "Done."
+
+    ##################
+    # Install themes #
+    ##################
+
+    echo "Installing themes..."
+
+    # Donut
+    DONUT_TAG=2.0.2
+    DONUT_FILE_NAME=Donut-${DONUT_TAG}
+    curl -L "https://github.com/amiyasahu/Donut/archive/2.0.2.zip" --output ${DONUT_FILE_NAME}.zip
+    unzip ${DONUT_FILE_NAME}.zip
+    rm ${DONUT_FILE_NAME}.zip
+
+    cp -r ${DONUT_FILE_NAME}/qa-plugin/Donut-admin ${Q2A_DIR}/qa-plugin/Donut
+    cp -r ${DONUT_FILE_NAME}/qa-theme/Donut-theme ${Q2A_DIR}/qa-theme/Donut
+    rm -rf ${DONUT_FILE_NAME}
+
+    echo "Done."
+
+    popd
+
+Environment variables
+---------------------
+Basically any environment variable declared for the container is available to
+be used by the scripts. Look at the `Environment variables` section of the
+deployment `README.md <../../README.md>`_ for more information.


### PR DESCRIPTION
This commit provides a Dockerfile based on php-fpm that contains the source
code of question2answer. The container also support init scripts that may be
used to install plugins, themes or configure the running instance.

The commit also provides a compose file which enables the possibility to run a
deploy of question2answers using docker stack.

Also includes a helm directory which enables the deploy of question2answers in
a kubernetes server using helm. For this, a public image of the Dockerfile is
needed but for now, there is none published; so you may have publish your own
until an official one is released.

Documentation about this files, how to deploy an image, a docker stack or helm
instance is also provided.