### PR TITLE
curl instead of file_get_contents

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1824,15 +1824,21 @@ function qa_retrieve_url($url)
 		return '';
 	}
 
-	$contents = @file_get_contents($url);
+        $contents = '';
+	// Due to the design of the file_get_contents function, sometimes getting external content will be very slow.
+	// You should use curl instead if possible. For details, see here: 
+	// https://stackoverflow.com/questions/3629504/php-file-get-contents-very- slow-when-using-full-url
+        if (function_exists('curl_exec')) {
+            $curl = curl_init($url);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
+            $contents = @curl_exec($curl);
+            curl_close($curl);
+        }
 
-	if (!strlen($contents) && function_exists('curl_exec')) { // try curl as a backup (if allow_url_fopen not set)
-		$curl = curl_init($url);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-		$contents = @curl_exec($curl);
-		curl_close($curl);
-	}
+        if (!strlen($contents)) {
+            $contents = @file_get_contents($url);
+        }
 
 	return $contents;
 }


### PR DESCRIPTION
Due to the design of the file_get_contents function, sometimes getting external content will be very slow. You should use curl instead if possible. For details, see here: https://stackoverflow.com/questions/3629504/php-file-get-contents-very- slow-when-using-full-url