### PR TITLE
Fix access array offset notice on post page.

### DIFF
--- a/qa-include/pages/question-view.php
+++ b/qa-include/pages/question-view.php
@@ -1131,7 +1131,7 @@ function qa_page_q_add_c_form(&$qa_content, $question, $parent, $formid, $captch
 				qa_set_up_name_field($qa_content, $form['fields'], @$in['name'], $prefix);
 
 			qa_set_up_notify_fields($qa_content, $form['fields'], 'C', qa_get_logged_in_email(),
-				isset($in['notify']) ? $in['notify'] : qa_opt('notify_users_default'), $in['email'], @$errors['email'], $prefix);
+				isset($in['notify']) ? $in['notify'] : qa_opt('notify_users_default'), @$in['email'], @$errors['email'], $prefix);
 
 			$onloads = array();
 


### PR DESCRIPTION
Getting "Notice: Trying to access array offset on value of type null in C:\...\qa-include\pages\questino-view.php on line 1131" on version 1.8.4