### PR TITLE
Increase security by setting the httpOnly flag to session cookie

### DIFF
--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -157,6 +157,7 @@ if (QA_FINAL_EXTERNAL_USERS) {
 		@ini_set('session.gc_maxlifetime', 86400); // worth a try, but won't help in shared hosting environment
 		@ini_set('session.use_trans_sid', false); // sessions need cookies to work, since we redirect after login
 		@ini_set('session.cookie_domain', QA_COOKIE_DOMAIN);
+		@ini_set('session.cookie_httponly', true);
 
 		if (!isset($_SESSION))
 			session_start();


### PR DESCRIPTION
According to Mozilla best-practices (see https://observatory.mozilla.org
and https://infosec.mozilla.org/guidelines/web_security#cookies )
session cookies should be created with the HttpOnly flag. This prevents
XSS vulnerabilities.

This PHPSESSID cookie is still sent over ajax calls (it just prevents JS to
access it) so it does not break any usage