### PR TITLE
qa_sanitize__html_hook_tag don't need to handle <embed> anymore

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1048,9 +1048,6 @@ function qa_sanitize_html_hook_tag($element, $attributes = null)
 	if ($element == 'param' && trim(strtolower(@$attributes['name'])) == 'allowscriptaccess')
 		$attributes['name'] = 'allowscriptaccess_denied';
 
-	if ($element == 'embed')
-		unset($attributes['allowscriptaccess']);
-
 	if ($element == 'a' && isset($attributes['href']) && $qa_sanitize_html_newwindow)
 		$attributes['target'] = '_blank';
 


### PR DESCRIPTION
Those two lines were used to remove potential "allowscriptaccess"
attribute from <embed> tag. It was probably made for security reasons.
But it turned out that even with this, it was dangerous to allow <embed>
tag. That's why 188f5e98792f2aca3afdd8a03d88e5732c7f5685 removed
completely the possibility to have <embed> tags (if there are some in
inputs, they are going to be completely deleted by htmLawed.
Consequently, the two lines removed by this commit are completely
useless since this other commit. Removing them makes this part of the
code a bit less complex to understand.