### PR TITLE
Cache core and plugin updates

### DIFF
--- a/qa-content/qa-admin.js
+++ b/qa-content/qa-admin.js
@@ -21,8 +21,7 @@
 
 var qa_recalc_running = 0;
 
-window.onbeforeunload = function(event)
-{
+window.onbeforeunload = function (event) {
 	if (qa_recalc_running > 0) {
 		event = event || window.event;
 		var message = qa_warning_recalc;
@@ -43,8 +42,9 @@ function qa_recalc_click(state, elem, value, noteid)
 
 		document.getElementById(noteid).innerHTML = '';
 		elem.qa_original_value = elem.value;
-		if (value)
+		if (value) {
 			elem.value = value;
+		}
 
 		qa_recalc_update(elem, state, noteid);
 	}
@@ -147,27 +147,24 @@ function qa_admin_click(target)
 	return false;
 }
 
-function qa_version_check(uri, version, elem, isCore)
+function qa_version_check(uri, version, elem, componentId)
 {
-	qa_ajax_post(
-		'version',
-		{uri: uri, version: version, isCore: isCore},
-		function (response) {
-			if (response.result === 'error') {
-				alert(response.error.message);
+	var params = {uri: uri, version: version, componentId: componentId};
+	qa_ajax_post('version', params, function (response) {
+		if (response.result === 'error') {
+			alert(response.error.message);
 
-				return;
-			}
+			return;
+		}
 
-			document.getElementById(elem).innerHTML = response.html;
-		}, 1
-	);
+		document.getElementById(elem).innerHTML = response.html;
+	}, 1);
 }
 
 function qa_version_check_array(versionChecks)
 {
 	for (var i = 0; i < versionChecks.length; i++) {
-		qa_version_check(versionChecks[i].uri, versionChecks[i].version, versionChecks[i].elem, false)
+		qa_version_check(versionChecks[i].uri, versionChecks[i].version, versionChecks[i].elem, versionChecks[i].componentId);
 	}
 }
 
@@ -175,8 +172,8 @@ function qa_get_enabled_plugins_hashes()
 {
 	var hashes = [];
 	$('[id^=plugin_enabled]:checked').each(
-		function(idx, elem) {
-			hashes.push(elem.id.replace("plugin_enabled_", ""));
+		function (idx, elem) {
+			hashes.push(elem.id.replace('plugin_enabled_', ''));
 		}
 	);
 

--- a/qa-include/app/options.php
+++ b/qa-include/app/options.php
@@ -149,6 +149,33 @@ function qa_load_options_results($results)
 
 
 /**
+ * Get option $name from the database
+ * @param string $name
+ * @return string
+ */
+function qa_db_get_option($name)
+{
+	global $qa_options_cache, $qa_options_loaded;
+
+	$selectSpec = [
+		'columns' => array('content'),
+		'source' => '^options WHERE title = #',
+		'arrayvalue' => 'content',
+		'single' => true,
+		'arguments' => [$name],
+	];
+
+	$value = qa_db_single_select($selectSpec);
+
+	if (isset($qa_options_loaded)) {
+		$qa_options_cache[$name] = $value;
+	}
+
+	return $value;
+}
+
+
+/**
  * Set an option $name to $value (application level) in both cache and database, unless
  * $todatabase=false, in which case set it in the cache only
  * @param string $name

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -1076,7 +1076,7 @@ foreach ($showoptions as $optionname) {
 					$updatehtml = '(<span id="' . $elementid . '">...</span>)';
 
 					$qa_content['script_onloads'][] = array(
-						"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ", false);"
+						"qa_version_check(" . qa_js($metadata['update_uri']) . ", " . qa_js($metadata['version'], true) . ", " . qa_js($elementid) . ", null);"
 					);
 
 				}

--- a/qa-src/Update/CoreUpdateManager.php
+++ b/qa-src/Update/CoreUpdateManager.php
@@ -1,0 +1,78 @@
+<?php
+/*
+	Question2Answer by Gideon Greenspan and contributors
+	http://www.question2answer.org/
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	More about this license: http://www.question2answer.org/license.php
+*/
+
+namespace Q2A\Update;
+
+/**
+ * Keeps track of the core version.
+ */
+class CoreUpdateManager
+{
+	const OPT_CORE_UPDATE_CACHE = 'core_update_cache';
+	const NUMBER_OF_DAYS_TO_CHECK_FOR_UPDATE = 28;
+
+	const OPT_FIELD_TIME = 'time';
+	const OPT_FIELD_VERSION = 'version';
+
+	/**
+	 * @return bool
+	 */
+	public function shouldCheckForUpdate()
+	{
+		$option = qa_opt(self::OPT_CORE_UPDATE_CACHE);
+		$option = json_decode($option, true);
+		$date = isset($option[self::OPT_FIELD_TIME])
+			? (int)$option[self::OPT_FIELD_TIME]
+			: 0;
+
+		$currentTime = (int)qa_opt('db_time');
+
+		return $currentTime - $date > self::NUMBER_OF_DAYS_TO_CHECK_FOR_UPDATE * 24 * 60 * 60;
+	}
+
+	/**
+	 * @param string $version
+	 * @param int|null $time
+	 */
+	public function setCachedVersion($version, $time = null)
+	{
+		if ($time === null) {
+			$time = (int)qa_opt('db_time');
+		}
+
+		$option = [
+			self::OPT_FIELD_TIME => $time,
+			self::OPT_FIELD_VERSION => $version,
+		];
+
+		qa_opt(self::OPT_CORE_UPDATE_CACHE, json_encode($option));
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getCachedVersion()
+	{
+		$option = qa_opt(self::OPT_CORE_UPDATE_CACHE);
+		$option = json_decode($option, true);
+
+		return isset($option[self::OPT_FIELD_VERSION])
+			? $option[self::OPT_FIELD_VERSION]
+			: null;
+	}
+}


### PR DESCRIPTION
Keeps track of pending plugin and core updates.

Plugins are checked on date set in the `plugin_update_last_check` option. Plugin IDs and versions are stored in the `plugin_update_cache` option, as JSON. Only updates are stored. It could be possible to use one option to store everything and include the last check date (as the core, below). I'm inclined to keep the rows used to the minimum, as long as they make sense.

The core works in the same way but the last check is stored in the same option row as the version and they are stored as a JSON object as well.

The approach invalidates the cache as discussed here: https://github.com/q2a/question2answer/pull/769#issuecomment-709853108