### PR TITLE
Fix point recalculations not working

### DIFF
--- a/qa-include/db/points.php
+++ b/qa-include/db/points.php
@@ -43,16 +43,19 @@ function qa_db_points_option_names()
 	);
 }
 
-
 /**
  * Returns an array containing all the calculation formulae for the userpoints table. Each element of this
  * array is for one column - the key contains the column name, and the value is a further array of two elements.
- * The element 'formula' contains the SQL fragment that calculates the columns value for one or more users,
- * and must contain one placeholder using ? for which the userid is passed as a parameter in the query.
+ * The element 'formula' contains the SQL fragment that calculates the columns value for one or more users.
+ * If $singleUser is set to TRUE, the formula will contain a single placeholder ('?'). Otherwise, the formula
+ * will contain two placeholders to match a range of user IDs.
  * The element 'multiple' specifies what to multiply each column by to create the final sum in the points column.
+ *
+ * @param bool $singleUser Detefines if the query will be built to match one user ID or a range of users IDs
+ *
  * @return mixed
  */
-function qa_db_points_calculations()
+function qa_db_points_calculations($singleUser)
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
@@ -60,60 +63,62 @@ function qa_db_points_calculations()
 
 	$options = qa_get_options(qa_db_points_option_names());
 
+	$userSql = $singleUser ? '= ?' : 'BETWEEN ? AND ?';
+
 	return array(
 		'qposts' => array(
 			'multiple' => $options['points_multiple'] * $options['points_post_q'],
-			'formula' => "COUNT(*) AS qposts FROM ^posts AS userid_src WHERE userid=? AND type='Q'",
+			'formula' => "COUNT(*) AS qposts FROM ^posts AS userid_src WHERE userid " . $userSql . " AND type='Q'",
 		),
 
 		'aposts' => array(
 			'multiple' => $options['points_multiple'] * $options['points_post_a'],
-			'formula' => "COUNT(*) AS aposts FROM ^posts AS userid_src WHERE userid=? AND type='A'",
+			'formula' => "COUNT(*) AS aposts FROM ^posts AS userid_src WHERE userid " . $userSql . " AND type='A'",
 		),
 
 		'cposts' => array(
 			'multiple' => 0,
-			'formula' => "COUNT(*) AS cposts FROM ^posts AS userid_src WHERE userid=? AND type='C'",
+			'formula' => "COUNT(*) AS cposts FROM ^posts AS userid_src WHERE userid " . $userSql . " AND type='C'",
 		),
 
 		'aselects' => array(
 			'multiple' => $options['points_multiple'] * $options['points_select_a'],
-			'formula' => "COUNT(*) AS aselects FROM ^posts AS userid_src WHERE userid=? AND type='Q' AND selchildid IS NOT NULL",
+			'formula' => "COUNT(*) AS aselects FROM ^posts AS userid_src WHERE userid " . $userSql . " AND type='Q' AND selchildid IS NOT NULL",
 		),
 
 		'aselecteds' => array(
 			'multiple' => $options['points_multiple'] * $options['points_a_selected'],
-			'formula' => "COUNT(*) AS aselecteds FROM ^posts AS userid_src JOIN ^posts AS questions ON questions.selchildid=userid_src.postid WHERE userid_src.userid=? AND userid_src.type='A' AND NOT (questions.userid<=>userid_src.userid)",
+			'formula' => "COUNT(*) AS aselecteds FROM ^posts AS userid_src JOIN ^posts AS questions ON questions.selchildid=userid_src.postid WHERE userid_src.userid " . $userSql . "  AND userid_src.type='A' AND NOT (questions.userid<=>userid_src.userid)",
 		),
 
 		'qupvotes' => array(
 			'multiple' => $options['points_multiple'] * $options['points_vote_up_q'],
-			'formula' => "COUNT(*) AS qupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='Q' AND userid_src.vote>0",
+			'formula' => "COUNT(*) AS qupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='Q' AND userid_src.vote>0",
 		),
 
 		'qdownvotes' => array(
 			'multiple' => $options['points_multiple'] * $options['points_vote_down_q'],
-			'formula' => "COUNT(*) AS qdownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='Q' AND userid_src.vote<0",
+			'formula' => "COUNT(*) AS qdownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='Q' AND userid_src.vote<0",
 		),
 
 		'aupvotes' => array(
 			'multiple' => $options['points_multiple'] * $options['points_vote_up_a'],
-			'formula' => "COUNT(*) AS aupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='A' AND userid_src.vote>0",
+			'formula' => "COUNT(*) AS aupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='A' AND userid_src.vote>0",
 		),
 
 		'adownvotes' => array(
 			'multiple' => $options['points_multiple'] * $options['points_vote_down_a'],
-			'formula' => "COUNT(*) AS adownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='A' AND userid_src.vote<0",
+			'formula' => "COUNT(*) AS adownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='A' AND userid_src.vote<0",
 		),
 
 		'cupvotes' => array(
 			'multiple' => 0,
-			'formula' => "COUNT(*) AS cupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='C' AND userid_src.vote>0",
+			'formula' => "COUNT(*) AS cupvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='C' AND userid_src.vote>0",
 		),
 
 		'cdownvotes' => array(
 			'multiple' => 0,
-			'formula' => "COUNT(*) AS cdownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid=? AND LEFT(^posts.type, 1)='C' AND userid_src.vote<0",
+			'formula' => "COUNT(*) AS cdownvotes FROM ^uservotes AS userid_src JOIN ^posts ON userid_src.postid=^posts.postid WHERE userid_src.userid " . $userSql . "  AND LEFT(^posts.type, 1)='C' AND userid_src.vote<0",
 		),
 
 		'qvoteds' => array(
@@ -122,7 +127,7 @@ function qa_db_points_calculations()
 				"LEAST(" . ((int)$options['points_per_q_voted_up']) . "*upvotes," . ((int)$options['points_q_voted_max_gain']) . ")" .
 				"-" .
 				"LEAST(" . ((int)$options['points_per_q_voted_down']) . "*downvotes," . ((int)$options['points_q_voted_max_loss']) . ")" .
-				"), 0) AS qvoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='Q' AND userid=?",
+				"), 0) AS qvoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='Q' AND userid " . $userSql,
 		),
 
 		'avoteds' => array(
@@ -131,7 +136,7 @@ function qa_db_points_calculations()
 				"LEAST(" . ((int)$options['points_per_a_voted_up']) . "*upvotes," . ((int)$options['points_a_voted_max_gain']) . ")" .
 				"-" .
 				"LEAST(" . ((int)$options['points_per_a_voted_down']) . "*downvotes," . ((int)$options['points_a_voted_max_loss']) . ")" .
-				"), 0) AS avoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='A' AND userid=?",
+				"), 0) AS avoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='A' AND userid " . $userSql,
 		),
 
 		'cvoteds' => array(
@@ -140,17 +145,17 @@ function qa_db_points_calculations()
 				"LEAST(" . ((int)$options['points_per_c_voted_up']) . "*upvotes," . ((int)$options['points_c_voted_max_gain']) . ")" .
 				"-" .
 				"LEAST(" . ((int)$options['points_per_c_voted_down']) . "*downvotes," . ((int)$options['points_c_voted_max_loss']) . ")" .
-				"), 0) AS cvoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='C' AND userid=?",
+				"), 0) AS cvoteds FROM ^posts AS userid_src WHERE LEFT(type, 1)='C' AND userid " . $userSql,
 		),
 
 		'upvoteds' => array(
 			'multiple' => 0,
-			'formula' => "COALESCE(SUM(upvotes), 0) AS upvoteds FROM ^posts AS userid_src WHERE userid=?",
+			'formula' => "COALESCE(SUM(upvotes), 0) AS upvoteds FROM ^posts AS userid_src WHERE userid " . $userSql,
 		),
 
 		'downvoteds' => array(
 			'multiple' => 0,
-			'formula' => "COALESCE(SUM(downvotes), 0) AS downvoteds FROM ^posts AS userid_src WHERE userid=?",
+			'formula' => "COALESCE(SUM(downvotes), 0) AS downvoteds FROM ^posts AS userid_src WHERE userid " . $userSql,
 		),
 	);
 }
@@ -174,7 +179,7 @@ function qa_db_points_update_ifuser($userid, $columns)
 		require_once QA_INCLUDE_DIR . 'app/options.php';
 		require_once QA_INCLUDE_DIR . 'app/cookies.php';
 
-		$calculations = qa_db_points_calculations();
+		$calculations = qa_db_points_calculations(true);
 
 		if ($columns === true) {
 			$keycolumns = $calculations;

--- a/qa-include/db/recalc.php
+++ b/qa-include/db/recalc.php
@@ -277,7 +277,7 @@ function qa_db_users_recalc_points($firstuserid, $lastuserid)
 {
 	require_once QA_INCLUDE_DIR . 'db/points.php';
 
-	$qa_userpoints_calculations = qa_db_points_calculations();
+	$qa_userpoints_calculations = qa_db_points_calculations(false);
 
 	qa_db_query_sub(
 		'DELETE FROM ^userpoints WHERE userid>=# AND userid<=# AND bonus=0', // delete those with no bonus


### PR DESCRIPTION
This should fix #841 

The issue is removing `~` in this commit be4f6d21ee3af555eda6465cac728b0f83381954 didn't allow the `~` to get replaced by a `BETWEEN ? AND ?`. One approach would be to just always use the `BETWEEN` keyword and always send the 2 parameters. This seems to be a bit dirty so I'm suggesting customizing the SQL to generate based on the amount of users to process.