### PR TITLE
removed hard codded font-size

### DIFF
--- a/qa-plugin/tag-cloud-widget/qa-tag-cloud.php
+++ b/qa-plugin/tag-cloud-widget/qa-tag-cloud.php
@@ -122,7 +122,7 @@ class qa_tag_cloud
 
 		$themeobject->output(sprintf('<h2 style="margin-top: 0; padding-top: 0;">%s</h2>', qa_lang_html('main/popular_tags')));
 
-		$themeobject->output('<div style="font-size: 10px;">');
+		$themeobject->output('<div class="tag-cloud">');
 
 		$maxsize = qa_opt('tag_cloud_font_size');
 		$minsize = qa_opt('tag_cloud_minimal_font_size');


### PR DESCRIPTION
removed hard codded font-size and added a class for custom styling

Lighthouse report :- Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. Learn more.