### PR TITLE
Fix duplicated mainEntity.suggestedAnswer.text microdata error

### DIFF
--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1029,6 +1029,7 @@ function qa_sanitize_html($html, $linksnewwindow = false, $storage = false)
 		'keep_bad' => 0,
 		'anti_link_spam' => array('/.*/', ''),
 		'hook_tag' => 'qa_sanitize_html_hook_tag',
+		'deny_attribute' => 'itemprop, itemscope, itemtype, itemid, itemref',
 	));
 
 	return $safe;


### PR DESCRIPTION
Finally, I got access to a link showing this error. I believe I've cracked it. It seems people copy/paste other answers. If they copy the part of the answer that includes microdata, then the microdata is also copied. So when they paste the content, they also paste the microdata from other original answer.

This results in an answer having the "text" attribute of its own and also a nested "text" attribute from the original answer. This should be fixed by just disallowing all microdata tags.