### PR TITLE
Fix captcha on feedback page not being shown for anonymous users

### DIFF
--- a/qa-include/ajax/answer.php
+++ b/qa-include/ajax/answer.php
@@ -49,7 +49,7 @@ if (@$question['basetype'] == 'Q' && !qa_post_is_closed($question) && !qa_user_p
 
 	// Try to create the new answer
 
-	$usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question));
+	$usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question), qa_opt('captcha_on_anon_post'));
 	$answers = qa_page_q_load_as($question, $childposts);
 	$answerid = qa_page_q_add_a_submit($question, $answers, $usecaptcha, $in, $errors);
 

--- a/qa-include/ajax/comment.php
+++ b/qa-include/ajax/comment.php
@@ -53,7 +53,7 @@ if (@$question['basetype'] == 'Q' && (@$parent['basetype'] == 'Q' || @$parent['b
 
 	// Try to create the new comment
 
-	$usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question));
+	$usecaptcha = qa_user_use_captcha(qa_user_level_for_post($question), qa_opt('captcha_on_anon_post'));
 	$commentid = qa_page_q_add_c_submit($question, $parent, $children, $usecaptcha, $in, $errors);
 
 

--- a/qa-include/app/users.php
+++ b/qa-include/app/users.php
@@ -1155,9 +1155,10 @@ function qa_permit_value_error($permit, $userid, $userlevel, $userflags)
  * 'confirm' => captcha required because the user has not confirmed their email address
  * false => captcha is not required
  * @param $userlevel
+ * @param bool $showCaptchaIfAnonymous
  * @return bool|mixed|string
  */
-function qa_user_captcha_reason($userlevel = null)
+function qa_user_captcha_reason($userlevel = null, $showCaptchaIfAnonymous = true)
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
@@ -1168,7 +1169,7 @@ function qa_user_captcha_reason($userlevel = null)
 	if ($userlevel < QA_USER_LEVEL_APPROVED) { // approved users and above aren't shown captchas
 		$userid = qa_get_logged_in_userid();
 
-		if (qa_opt('captcha_on_anon_post') && !isset($userid))
+		if ($showCaptchaIfAnonymous && !isset($userid))
 			$reason = 'login';
 		elseif (qa_opt('moderate_users') && qa_opt('captcha_on_unapproved'))
 			$reason = 'approve';
@@ -1179,18 +1180,18 @@ function qa_user_captcha_reason($userlevel = null)
 	return $reason;
 }
 
-
 /**
  * Return whether a captcha should be presented to the logged in user for writing posts. You can pass in a
  * QA_USER_LEVEL_* constant in $userlevel to consider the user at a different level to usual.
  * @param $userlevel
+ * @param bool $showCaptchaIfAnonymous
  * @return bool|mixed
  */
-function qa_user_use_captcha($userlevel = null)
+function qa_user_use_captcha($userlevel = null, $showCaptchaIfAnonymous = true)
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-	return qa_user_captcha_reason($userlevel) != false;
+	return qa_user_captcha_reason($userlevel, $showCaptchaIfAnonymous) != false;
 }
 
 

--- a/qa-include/pages/ask.php
+++ b/qa-include/pages/ask.php
@@ -95,7 +95,7 @@ if ($permiterror) {
 
 // Process input
 
-$captchareason = qa_user_captcha_reason();
+$captchareason = qa_user_captcha_reason(null, qa_opt('captcha_on_anon_post'));
 
 $in['title'] = qa_get_post_title('title'); // allow title and tags to be posted by an external form
 $in['extra'] = qa_opt('extra_field_active') ? qa_post_text('extra') : null;

--- a/qa-include/pages/feedback.php
+++ b/qa-include/pages/feedback.php
@@ -41,7 +41,6 @@ if (isset($userid) && !QA_FINAL_EXTERNAL_USERS) {
 
 $usecaptcha = qa_opt('captcha_on_feedback') && qa_user_use_captcha();
 
-
 // Check feedback is enabled and the person isn't blocked
 
 if (!qa_opt('feedback_enabled'))

--- a/qa-include/pages/question.php
+++ b/qa-include/pages/question.php
@@ -167,7 +167,7 @@ if ($saveCache) {
 
 // Determine if captchas will be required
 
-$captchareason = qa_user_captcha_reason(qa_user_level_for_post($question));
+$captchareason = qa_user_captcha_reason(qa_user_level_for_post($question), qa_opt('captcha_on_anon_post'));
 $usecaptcha = ($captchareason != false);
 
 


### PR DESCRIPTION
When the "Use captcha for anonymous posts" setting is unchecked, captcha is not showing on feedback form, as it is treated as an anonymous post.

I could just fix this by checking if the user is anonymous and, if it is, just avoid calling the `qa_user_captcha_reason()`. The thing is that I would be getting part of the logic from that function out of the function. So I'd rather keep the logic (the `if` statement) in the function and just send the function the actual data to process it.

In other words, I think it is better to change the signature from:

```php
function qa_user_captcha_reason($userlevel = null)
```

to:

```php
function qa_user_captcha_reason($userlevel = null, $showCaptchaIfAnonymous = true)
```

This way the

```php
if (qa_opt('captcha_on_anon_post') && !isset($userid))
```

would become parameterizable and the caller will determine if the captcha should respect the `captcha_on_anon_post` or any other setting or criteria.

Changes should be backwards-compatible as well