### PR TITLE
Invalidate cache when performing additional post operations

### DIFF
--- a/qa-include/app/post-create.php
+++ b/qa-include/app/post-create.php
@@ -29,6 +29,7 @@ require_once QA_INCLUDE_DIR . 'db/post-create.php';
 require_once QA_INCLUDE_DIR . 'db/points.php';
 require_once QA_INCLUDE_DIR . 'db/hotness.php';
 require_once QA_INCLUDE_DIR . 'util/string.php';
+require_once QA_INCLUDE_DIR . 'app/post-update.php';
 
 
 /**
@@ -225,6 +226,8 @@ function qa_answer_create($userid, $handle, $cookieid, $content, $format, $text,
 		qa_db_points_update_ifuser($userid, 'aposts');
 	}
 
+	qa_question_uncache($question['postid']);
+
 	qa_report_event($queued ? 'a_queue' : 'a_post', $userid, $handle, $cookieid, array(
 		'postid' => $postid,
 		'parentid' => $question['postid'],
@@ -312,6 +315,8 @@ function qa_comment_create($userid, $handle, $cookieid, $content, $format, $text
 		if ($comment['type'] == 'C' && $comment['parentid'] == $parent['postid']) // find just those for this parent, fully visible
 			$thread[] = $comment;
 	}
+
+	qa_question_uncache($question['postid']);
 
 	qa_report_event($queued ? 'c_queue' : 'c_post', $userid, $handle, $cookieid, array(
 		'postid' => $postid,

--- a/qa-include/app/post-update.php
+++ b/qa-include/app/post-update.php
@@ -111,6 +111,8 @@ function qa_question_set_content($oldquestion, $title, $content, $format, $text,
 		}
 	}
 
+	qa_question_uncache($oldquestion['postid']);
+
 	$eventparams = array(
 		'postid' => $oldquestion['postid'],
 		'title' => $title,
@@ -684,6 +686,8 @@ function qa_answer_set_content($oldanswer, $content, $format, $text, $notify, $u
 		qa_post_index($oldanswer['postid'], 'A', $question['postid'], $oldanswer['parentid'], null, $content, $format, $text, null, $oldanswer['categoryid']);
 	}
 
+	qa_question_uncache($question['postid']);
+
 	$eventparams = array(
 		'postid' => $oldanswer['postid'],
 		'parentid' => $oldanswer['parentid'],
@@ -972,6 +976,8 @@ function qa_comment_set_content($oldcomment, $content, $format, $text, $notify, 
 	} elseif ($oldcomment['type'] == 'C' && $question['type'] == 'Q' && ($parent['type'] == 'Q' || $parent['type'] == 'A')) { // all must be visible
 		qa_post_index($oldcomment['postid'], 'C', $question['postid'], $oldcomment['parentid'], null, $content, $format, $text, null, $oldcomment['categoryid']);
 	}
+
+	qa_question_uncache($question['postid']);
 
 	$eventparams = array(
 		'postid' => $oldcomment['postid'],


### PR DESCRIPTION
There are a few situations that were being missed when invalidating question caches:

 * Creating answers
 * Creating comments
 * Updating content of question
 * Updating content of answer
 * Updating content of comment

Having these cache invalidations set would allow users to configure longer cache periods.