### PR TITLE
Avoid joining with users table to get userid several times on user profile page

### DIFF
--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -43,18 +43,25 @@ if (qa_clicked('doaccount'))
 
 
 $loginuserid = qa_get_logged_in_userid();
-$identifier = QA_FINAL_EXTERNAL_USERS ? $userid : $handle;
 
-list($useraccount, $userprofile, $userfields, $usermessages, $userpoints, $userlevels, $navcategories, $userrank) =
+if (!QA_FINAL_EXTERNAL_USERS) {
+	$useraccount = qa_db_single_select(qa_db_user_account_selectspec($handle, false));
+	if ($useraccount === null) {
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
+
+	$userid = $useraccount['userid'];
+}
+
+list($userprofile, $userfields, $usermessages, $userpoints, $userlevels, $navcategories, $userrank) =
 	qa_db_select_with_pending(
-		QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_account_selectspec($handle, false),
-		QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_profile_selectspec($handle, false),
+		QA_FINAL_EXTERNAL_USERS ? null : qa_db_user_profile_selectspec($userid, true),
 		QA_FINAL_EXTERNAL_USERS ? null : qa_db_userfields_selectspec(),
-		QA_FINAL_EXTERNAL_USERS ? null : qa_db_recent_messages_selectspec(null, null, $handle, false, qa_opt_if_loaded('page_size_wall')),
-		qa_db_user_points_selectspec($identifier),
-		qa_db_user_levels_selectspec($identifier, QA_FINAL_EXTERNAL_USERS, true),
+		QA_FINAL_EXTERNAL_USERS ? null : qa_db_recent_messages_selectspec(null, null, $userid, true, qa_opt_if_loaded('page_size_wall')),
+		qa_db_user_points_selectspec($userid, true),
+		qa_db_user_levels_selectspec($userid, true, true),
 		qa_db_category_nav_selectspec(null, true),
-		qa_db_user_rank_selectspec($identifier)
+		qa_db_user_rank_selectspec($userid, true)
 	);
 
 if (!QA_FINAL_EXTERNAL_USERS && $handle !== qa_get_logged_in_handle()) {
@@ -74,10 +81,9 @@ $loginlevel = qa_get_logged_in_level();
 if (!QA_FINAL_EXTERNAL_USERS) { // if we're using integrated user management, we can know and show more
 	require_once QA_INCLUDE_DIR . 'app/messages.php';
 
-	if (!is_array($userpoints) && !is_array($useraccount))
+	if (!is_array($userpoints))
 		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
 
-	$userid = $useraccount['userid'];
 	$fieldseditable = false;
 	$maxlevelassign = null;
 


### PR DESCRIPTION
Fetching the user account data early will return the userid of the profile's users. Doing this separately will avoid several lookups in the ^users table to turn the handle to a userid.

The only downside is that, for far away servers, the performance gain might be loss because of the latency of running two queries. I believe these affected users should be much less than 1%. Furthermore, if the result for them is having slower times than before, then using Q2A for those users was already a pretty bad experience.