### PR TITLE
Main Navigation Reorder / Footer Scripts / Plugins' CSS

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -1461,7 +1461,7 @@ function qa_user_sub_navigation($handle, $selected, $ismyuser = false)
 {
 	$navigation = array(
 		'profile' => array(
-			'label' => qa_lang_html_sub('profile/user_x', qa_html($handle)),
+			'label' => qa_lang_html_sub('profile/user_profile', qa_html($handle)),
 			'url' => qa_path_html('user/' . $handle),
 		),
 

--- a/qa-include/app/page.php
+++ b/qa-include/app/page.php
@@ -512,6 +512,25 @@ function qa_content_prepare($voting = false, $categoryids = array())
 		if ($page['nav'] == 'B')
 			qa_navigation_add_page($qa_content['navigation']['main'], $page);
 	}
+	
+	// Only the 'level' permission error prevents the menu option being shown - others reported on /qa-include/pages/ask.php
+
+	if (qa_opt('nav_ask') && qa_user_maximum_permit_error('permit_post_q') != 'level') {
+		$qa_content['navigation']['main']['ask'] = array(
+			'url' => qa_path_html('ask', (qa_using_categories() && strlen($lastcategoryid)) ? array('cat' => $lastcategoryid) : null),
+			'label' => qa_lang_html('main/nav_ask'),
+		);
+	}
+	
+	if (qa_get_logged_in_level() >= QA_USER_LEVEL_ADMIN || !qa_user_maximum_permit_error('permit_moderate') ||
+		!qa_user_maximum_permit_error('permit_hide_show') || !qa_user_maximum_permit_error('permit_delete_hidden')
+	) {
+		$qa_content['navigation']['main']['admin'] = array(
+			'url' => qa_path_html('admin'),
+			'label' => qa_lang_html('main/nav_admin'),
+			'selected_on' => array('admin/'),
+		);
+	}
 
 	if (qa_opt('nav_home') && qa_opt('show_custom_home')) {
 		$qa_content['navigation']['main']['$'] = array(
@@ -519,20 +538,20 @@ function qa_content_prepare($voting = false, $categoryids = array())
 			'label' => qa_lang_html('main/nav_home'),
 		);
 	}
-
-	if (qa_opt('nav_activity')) {
-		$qa_content['navigation']['main']['activity'] = array(
-			'url' => qa_path_html('activity'),
-			'label' => qa_lang_html('main/nav_activity'),
-		);
-	}
-
+	
 	$hascustomhome = qa_has_custom_home();
 
 	if (qa_opt($hascustomhome ? 'nav_qa_not_home' : 'nav_qa_is_home')) {
 		$qa_content['navigation']['main'][$hascustomhome ? 'qa' : '$'] = array(
 			'url' => qa_path_html($hascustomhome ? 'qa' : ''),
 			'label' => qa_lang_html('main/nav_qa'),
+		);
+	}
+
+	if (qa_opt('nav_activity')) {
+		$qa_content['navigation']['main']['activity'] = array(
+			'url' => qa_path_html('activity'),
+			'label' => qa_lang_html('main/nav_activity'),
 		);
 	}
 
@@ -578,26 +597,6 @@ function qa_content_prepare($voting = false, $categoryids = array())
 			'url' => qa_path_html('users'),
 			'label' => qa_lang_html('main/nav_users'),
 			'selected_on' => array('users$', 'users/', 'user/'),
-		);
-	}
-
-	// Only the 'level' permission error prevents the menu option being shown - others reported on /qa-include/pages/ask.php
-
-	if (qa_opt('nav_ask') && qa_user_maximum_permit_error('permit_post_q') != 'level') {
-		$qa_content['navigation']['main']['ask'] = array(
-			'url' => qa_path_html('ask', (qa_using_categories() && strlen($lastcategoryid)) ? array('cat' => $lastcategoryid) : null),
-			'label' => qa_lang_html('main/nav_ask'),
-		);
-	}
-
-
-	if (qa_get_logged_in_level() >= QA_USER_LEVEL_ADMIN || !qa_user_maximum_permit_error('permit_moderate') ||
-		!qa_user_maximum_permit_error('permit_hide_show') || !qa_user_maximum_permit_error('permit_delete_hidden')
-	) {
-		$qa_content['navigation']['main']['admin'] = array(
-			'url' => qa_path_html('admin'),
-			'label' => qa_lang_html('main/nav_admin'),
-			'selected_on' => array('admin/'),
 		);
 	}
 

--- a/qa-include/app/page.php
+++ b/qa-include/app/page.php
@@ -525,9 +525,16 @@ function qa_content_prepare($voting = false, $categoryids = array())
 	if (qa_get_logged_in_level() >= QA_USER_LEVEL_ADMIN || !qa_user_maximum_permit_error('permit_moderate') ||
 		!qa_user_maximum_permit_error('permit_hide_show') || !qa_user_maximum_permit_error('permit_delete_hidden')
 	) {
+		// Check moderation queue, if needs moderation, outputs a Red Dot as a reminder for Moderators
+		$qa_needs_mod = '';
+		
+		if (!empty(qa_opt('cache_queuedcount')) || !empty(qa_opt('cache_flaggedcount')) ){
+			$qa_needs_mod = '<span class="qa-needs-moderation"></span>';
+		}
+		
 		$qa_content['navigation']['main']['admin'] = array(
 			'url' => qa_path_html('admin'),
-			'label' => qa_lang_html('main/nav_admin'),
+			'label' => qa_lang_html('main/nav_admin'). $qa_needs_mod,
 			'selected_on' => array('admin/'),
 		);
 	}

--- a/qa-include/lang/qa-lang-profile.php
+++ b/qa-include/lang/qa-lang-profile.php
@@ -78,6 +78,7 @@ return array(
 	'send_private_message' => ' - ^1send private message^2',
 	'set_bonus_button' => 'Update bonus',
 	'title' => 'Title:',
+	'user_profile' => 'Profile',
 	'user_x' => 'User ^',
 	'user_x_disabled_pms' => 'User ^ has disabled private messages.',
 	'voted_on' => 'Voted on:',

--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -387,6 +387,8 @@ class qa_html_theme_base
 
 	public function head_css()
 	{
+		$this->plugin_css();
+		
 		$this->output('<link rel="stylesheet" href="' . $this->rooturl . $this->css_name() . '"/>');
 
 		if (isset($this->content['css_src'])) {
@@ -402,8 +404,6 @@ class qa_html_theme_base
 				'</style>'
 			);
 		}
-		
-		$this->plugin_css();
 		
 	}
 	

--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -382,7 +382,7 @@ class qa_html_theme_base
 	
 	public function footer_scripts()
 	{
-		// Footer Scripts.
+		// Footer Scripts
 	}
 
 	public function head_css()
@@ -402,6 +402,14 @@ class qa_html_theme_base
 				'</style>'
 			);
 		}
+		
+		$this->plugin_css();
+		
+	}
+	
+	public function plugin_css()
+	{
+		// Plugins CSS
 	}
 
 	public function css_name()

--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -371,6 +371,19 @@ class qa_html_theme_base
 			}
 		}
 	}
+	
+	public function footer_script_container()
+	{
+		$this->output('<div id="footer-scripts">');
+			// Footer Scripts. New container to group Footer scripts. Right before BODY tag closure.
+			$this->footer_scripts();
+		$this->output('</div>');
+	}
+	
+	public function footer_scripts()
+	{
+		// Footer Scripts.
+	}
 
 	public function head_css()
 	{
@@ -421,6 +434,8 @@ class qa_html_theme_base
 		$this->body_content();
 		$this->body_footer();
 		$this->body_hidden();
+		
+		$this->footer_script_container();
 
 		$this->output('</body>');
 	}

--- a/qa-theme/Candy/qa-styles.css
+++ b/qa-theme/Candy/qa-styles.css
@@ -114,6 +114,8 @@ h2 {font-size:22px; color:#c659ab; padding-top:12px; clear:both;}
 .qa-nav-main-link:hover,.qa-nav-main-selected {background: url(nav-main-sel-bg.png) repeat-x left top; border-left:1px solid #e9e697; border-right:1px solid #e9e697; color:#8d006a; padding:14px 9px; text-decoration:none;}
 .qa-nav-main-hot .qa-nav-main-link {color:#c33;}
 
+.qa-needs-moderation {display:inline-block; width:7px; height:7px; background-color:#f83052; border-radius:50%; vertical-align:text-top; margin:0 8px; margin-inline-end:0;}
+
 .qa-nav-sub {clear:both; background:url(nav-sub-bg.png) repeat-x left top;}
 * html .qa-nav-sub {background:none;} /* IE6 since z-order goes wrong */
 .qa-nav-sub-list {font-size:12px; list-style:none; padding:0; margin:0;}

--- a/qa-theme/Classic/qa-styles.css
+++ b/qa-theme/Classic/qa-styles.css
@@ -116,6 +116,8 @@ h2 {font-size:16px; padding-top:12px; clear:both;}
 .qa-nav-main-hot .qa-nav-main-link {background:#f33;}
 .qa-nav-main-hot .qa-nav-main-link:hover, .qa-nav-main-hot .qa-nav-main-selected {background:#f66;}
 
+.qa-needs-moderation {display:inline-block; width:7px; height:7px; background-color:#f83052; border-radius:50%; vertical-align:text-top; margin:0 8px; margin-inline-end:0;}
+
 .qa-nav-sub {clear:both; float:left; padding-top:3px;}
 .qa-nav-sub-list {font-size:12px; list-style:none; padding:0; margin:0;}
 .qa-nav-sub-item {float:left; margin-right:2px;margin-bottom:2px;}

--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -510,6 +510,17 @@ div.header-banner {
 	border-left: none;
 }
 
+.qa-needs-moderation {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    background-color: #f83052;
+    border-radius: 50%;
+    vertical-align: text-top;
+    margin: 0 8px;
+	margin-inline-end:0; /* Quick fix for modern browsers / Lack of RTL file */
+}
+
 .qa-nav-sub {
 	background: #f4f4f4; /* Old browsers */
 	background: -webkit-linear-gradient(top, #f4f4f4 0%, #e6e6e6 100%); /* Chrome10+,Safari5.1+ */

--- a/qa-theme/Snow/qa-theme.php
+++ b/qa-theme/Snow/qa-theme.php
@@ -162,4 +162,10 @@ class qa_html_theme extends qa_html_theme_base
 
 		qa_html_theme_base::attribution();
 	}
+	
+	public function footer_scripts()
+	{
+		// Footer Scripts. Add scripts to a container located right before BODY tag closure.
+	}
+	
 }

--- a/qa-theme/SnowFlat/qa-styles-rtl.css
+++ b/qa-theme/SnowFlat/qa-styles-rtl.css
@@ -53,6 +53,11 @@ h1 {
 	margin: 0 0 0 1px;
 }
 
+.qa-needs-moderation {
+    margin-left: initial;
+	margin-right: 8px;
+}
+
 @media (max-width: 979px) {
 	.qam-search-mobile {
 		border-left: 0;

--- a/qa-theme/SnowFlat/qa-styles-rtl.css
+++ b/qa-theme/SnowFlat/qa-styles-rtl.css
@@ -441,6 +441,10 @@ h1 {
 	.qam-footer-col {
 		float: right;
 	}
+	
+	li.qa-nav-main-item.qa-nav-main-ask, li.qa-nav-main-item.qa-nav-main-admin {
+		float: left;
+	}
 }
 
 .qa-vote-buttons {

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -563,6 +563,16 @@ blockquote p {
 	content: '\e80d';
 }
 
+.qa-needs-moderation {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    background-color: #f83052;
+    border-radius: 50%;
+    vertical-align: text-top;
+    margin-left: 8px;
+}
+
 @media (max-width: 979px) {
 	.qa-nav-main-link {
 		padding: 5px 10px;

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -480,6 +480,11 @@ blockquote p {
 	.qa-nav-main-item-opp:last-child {
 		margin: 0 0 0 50px;
 	}
+	
+	li.qa-nav-main-item.qa-nav-main-ask, li.qa-nav-main-item.qa-nav-main-admin {
+		float: right;
+	}
+	
 }
 
 .qa-nav-main-list {

--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -700,4 +700,10 @@ class qa_html_theme extends qa_html_theme_base
 			'</div>' .
 			'</div>';
 	}
+	
+	public function footer_scripts()
+	{
+		// Footer Scripts. Add scripts to a container located right before BODY tag closure.
+	}
+	
 }


### PR DESCRIPTION
Re ordered "Ask a question" and "Admin" links in Main Navigation, so they're displayed at the very top in vertical menus (mobile devices for example).

For horizontal menus (Desktop) a 'floating:right;' can be applied for these menu items, so they're displayed at the far right end, as they were before.