### PR TITLE
Some improvements to the cache driver

### DIFF
--- a/qa-config-example.php
+++ b/qa-config-example.php
@@ -99,6 +99,15 @@
 */
 
 /*
+	If you wish to use memcached-based caching, you can define the host and port in which the
+	memcached server resides. Default values are 127.0.0.1 and 11211, respectively. You only need
+	to define the constats below if you want to use different values for them.
+
+	define('QA_MEMCACHED_HOST', '123.123.123.123');
+	define('QA_MEMCACHED_PORT', 12345);
+*/
+
+/*
 	If you wish, you can define QA_COOKIE_DOMAIN so that any cookies created by Q2A are assigned
 	to a specific domain name, instead of the full domain name of the request by default. This is
 	useful if you're running multiple Q2A sites on subdomains with a shared user base.

--- a/qa-include/Q2A/Storage/CacheDriver.php
+++ b/qa-include/Q2A/Storage/CacheDriver.php
@@ -57,7 +57,7 @@ interface Q2A_Storage_CacheDriver
 	 * @param int $start Offset from which to start (used for 'batching' deletes).
 	 * @param bool $expiredOnly Delete cache only if it has expired.
 	 *
-	 * @return int Number of files deleted.
+	 * @return int Number of items deleted.
 	 */
 	public function clear($limit = 0, $start = 0, $expiredOnly = false);
 
@@ -69,13 +69,6 @@ interface Q2A_Storage_CacheDriver
 	public function isEnabled();
 
 	/**
-	 * Get the last error.
-	 *
-	 * @return string
-	 */
-	public function getError();
-
-	/**
 	 * Get the prefix used for all cache keys.
 	 *
 	 * @return string
@@ -85,7 +78,14 @@ interface Q2A_Storage_CacheDriver
 	/**
 	 * Get current statistics for the cache.
 	 *
-	 * @return array Array of stats: 'files' => number of files, 'size' => total file size in bytes.
+	 * @return array Array of stats: 'items' => number of items, 'size' => total item size in bytes.
 	 */
 	public function getStats();
+
+	/**
+	 * Perform test operations and return an error string or null if no error was found
+	 *
+	 * @return string|null
+	 */
+	public function test();
 }

--- a/qa-include/Q2A/Storage/CacheFactory.php
+++ b/qa-include/Q2A/Storage/CacheFactory.php
@@ -37,23 +37,22 @@ class Q2A_Storage_CacheFactory
 			$config = array(
 				'enabled' => (int) qa_opt('caching_enabled') === 1,
 				'keyprefix' => QA_FINAL_MYSQL_DATABASE . '.' . QA_MYSQL_TABLE_PREFIX . '.',
-				'dir' => defined('QA_CACHE_DIRECTORY') ? QA_CACHE_DIRECTORY : null,
 			);
 
 			$driver = qa_opt('caching_driver');
 
-			switch($driver)
-			{
+			switch ($driver) {
 				case 'memcached':
 					self::$cacheDriver = new Q2A_Storage_MemcachedDriver($config);
 					break;
 
 				case 'filesystem':
 				default:
+					$config['dir'] = defined('QA_CACHE_DIRECTORY') ? QA_CACHE_DIRECTORY : null;
+
 					self::$cacheDriver = new Q2A_Storage_FileCacheDriver($config);
 					break;
 			}
-
 		}
 
 		return self::$cacheDriver;

--- a/qa-include/Q2A/Storage/MemcachedDriver.php
+++ b/qa-include/Q2A/Storage/MemcachedDriver.php
@@ -31,8 +31,8 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	private $error;
 	private $flushed = false;
 
-	const HOST = '127.0.0.1';
-	const PORT = 11211;
+	private $host = '127.0.0.1';
+	private $port = 11211;
 
 	/**
 	 * Creates a new Memcached instance and checks we can cache items.
@@ -51,8 +51,15 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 		}
 
 		if (extension_loaded('memcached')) {
+			if (defined('QA_MEMCACHED_HOST')) {
+				$this->host = QA_MEMCACHED_HOST;
+			}
+			if (defined('QA_MEMCACHED_PORT')) {
+				$this->port = QA_MEMCACHED_PORT;
+			}
+
 			$this->memcached = new Memcached;
-			$this->memcached->addServer(self::HOST, self::PORT);
+			$this->memcached->addServer($this->host, $this->port);
 			if ($this->memcached->set($this->keyPrefix . 'test', 'TEST')) {
 				$this->enabled = true;
 			} else {
@@ -196,7 +203,7 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 
 		if ($this->enabled) {
 			$stats = $this->memcached->getStats();
-			$key = self::HOST . ':' . self::PORT;
+			$key = $this->host . ':' . $this->port;
 
 			$totalFiles = isset($stats[$key]['curr_items']) ? $stats[$key]['curr_items'] : 0;
 			$totalBytes = isset($stats[$key]['bytes']) ? $stats[$key]['bytes'] : 0;

--- a/qa-include/Q2A/Storage/MemcachedDriver.php
+++ b/qa-include/Q2A/Storage/MemcachedDriver.php
@@ -28,7 +28,6 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	private $memcached;
 	private $enabled = false;
 	private $keyPrefix = '';
-	private $error;
 	private $flushed = false;
 
 	private $host = '127.0.0.1';
@@ -50,24 +49,21 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 			$this->keyPrefix = $config['keyprefix'];
 		}
 
-		if (extension_loaded('memcached')) {
-			if (defined('QA_MEMCACHED_HOST')) {
-				$this->host = QA_MEMCACHED_HOST;
-			}
-			if (defined('QA_MEMCACHED_PORT')) {
-				$this->port = QA_MEMCACHED_PORT;
-			}
-
-			$this->memcached = new Memcached;
-			$this->memcached->addServer($this->host, $this->port);
-			if ($this->memcached->set($this->keyPrefix . 'test', 'TEST')) {
-				$this->enabled = true;
-			} else {
-				$this->setMemcachedError();
-			}
-		} else {
-			$this->error = qa_lang_html('admin/no_memcached');
+		if (!extension_loaded('memcached')) {
+			return;
 		}
+
+		if (defined('QA_MEMCACHED_HOST')) {
+			$this->host = QA_MEMCACHED_HOST;
+		}
+		if (defined('QA_MEMCACHED_PORT')) {
+			$this->port = QA_MEMCACHED_PORT;
+		}
+
+		$this->memcached = new Memcached;
+		$this->memcached->addServer($this->host, $this->port);
+
+		$this->enabled = true;
 	}
 
 	/**
@@ -84,12 +80,7 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 
 		$result = $this->memcached->get($this->keyPrefix . $key);
 
-		if ($result === false) {
-			$this->setMemcachedError();
-			return null;
-		}
-
-		return $result;
+		return $this->memcached->getResultCode() === Memcached::RES_SUCCESS ? $result : null;
 	}
 
 	/**
@@ -98,7 +89,7 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	 * @param mixed $data The data to cache (in core Q2A this is usually an array).
 	 * @param int $ttl Number of minutes for which to cache the data.
 	 *
-	 * @return bool Whether the file was successfully cached.
+	 * @return bool Whether the item was successfully cached.
 	 */
 	public function set($key, $data, $ttl)
 	{
@@ -106,15 +97,9 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 			return false;
 		}
 
-		$ttl = (int) $ttl;
-		$expiry = time() + ($ttl * 60);
-		$success = $this->memcached->set($this->keyPrefix . $key, $data, $expiry);
+		$expiry = time() + ((int)$ttl * 60);
 
-		if (!$success) {
-			$this->setMemcachedError();
-		}
-
-		return $success;
+		return $this->memcached->set($this->keyPrefix . $key, $data, $expiry);
 	}
 
 	/**
@@ -129,13 +114,7 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 			return false;
 		}
 
-		$success = $this->memcached->delete($this->keyPrefix . $key);
-
-		if (!$success) {
-			$this->setMemcachedError();
-		}
-
-		return $success;
+		return $this->memcached->delete($this->keyPrefix . $key);
 	}
 
 	/**
@@ -144,18 +123,14 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	 * @param int $start Offset from which to start (used for 'batching' deletes).
 	 * @param bool $expiredOnly This parameter is ignored because Memcached automatically clears expired items.
 	 *
-	 * @return int Number of files deleted. For Memcached we return 0
+	 * @return int Number of elements deleted. For Memcached we return 0
 	 */
 	public function clear($limit = 0, $start = 0, $expiredOnly = false)
 	{
 		if ($this->enabled && !$expiredOnly && !$this->flushed) {
-			$success = $this->memcached->flush();
 			// avoid multiple calls to flush()
 			$this->flushed = true;
-
-			if (!$success) {
-				$this->setMemcachedError();
-			}
+			$this->memcached->flush();
 		}
 
 		return 0;
@@ -172,16 +147,6 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	}
 
 	/**
-	 * Get the last error.
-	 *
-	 * @return string
-	 */
-	public function getError()
-	{
-		return $this->error;
-	}
-
-	/**
 	 * Get the prefix used for all cache keys.
 	 *
 	 * @return string
@@ -194,7 +159,7 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 	/**
 	 * Get current statistics for the cache.
 	 *
-	 * @return array Array of stats: 'files' => number of files, 'size' => total file size in bytes.
+	 * @return array Array of stats: 'items' => number of files, 'size' => total item size in bytes.
 	 */
 	public function getStats()
 	{
@@ -210,18 +175,46 @@ class Q2A_Storage_MemcachedDriver implements Q2A_Storage_CacheDriver
 		}
 
 		return array(
-			'files' => $totalFiles,
+			'items' => $totalFiles,
 			'size' => $totalBytes,
 		);
 	}
 
 	/**
-	 * Set current error to Memcached result message
-	 *
-	 * @return void
+	 * Return result code from Memcached instance
 	 */
-	private function setMemcachedError()
+	public function getResultCode()
 	{
-		$this->error = qa_lang_html_sub('admin/memcached_error', $this->memcached->getResultMessage());
+		return isset($this->memcached) ? $this->memcached->getResultCode() : null;
+	}
+
+	/**
+	 * Return result message from Memcached instance
+	 */
+	public function getResultMessage()
+	{
+		return isset($this->memcached) ? $this->memcached->getResultMessage() : null;
+	}
+
+	/**
+	 * Perform test operations and return an error string or null if no error was found
+	 *
+	 * @return string|null
+	 */
+	public function test()
+	{
+		if (!extension_loaded('memcached')) {
+			return qa_lang_html('admin/no_memcached');
+		}
+
+		if (!$this->enabled) {
+			return null;
+		}
+
+		if (!$this->memcached->set($this->keyPrefix . 'test', 'TEST')) {
+			return qa_lang_html_sub('admin/memcached_error', $this->memcached->getResultMessage());
+		}
+
+		return null;
 	}
 }

--- a/qa-include/pages/admin/admin-default.php
+++ b/qa-include/pages/admin/admin-default.php
@@ -1804,7 +1804,7 @@ switch ($adminsection) {
 
 	case 'caching':
 		$cacheDriver = Q2A_Storage_CacheFactory::getCacheDriver();
-		$qa_content['error'] = $cacheDriver->getError();
+		$qa_content['error'] = $cacheDriver->test();
 		$cacheStats = $cacheDriver->getStats();
 
 		$qa_content['form_2'] = array(
@@ -1818,7 +1818,7 @@ switch ($adminsection) {
 				'cache_files' => array(
 					'type' => 'static',
 					'label' => qa_lang_html('admin/caching_num_items'),
-					'value' => qa_html(qa_format_number($cacheStats['files'])),
+					'value' => qa_html(qa_format_number($cacheStats['items'])),
 				),
 				'cache_size' => array(
 					'type' => 'static',


### PR DESCRIPTION
- Avoid testing the cache driver each time it was instantiated. The test is kept in admin/caching, but each instantiation of the driver will assume it is properly configured.
- Made host and port configurable