### PR TITLE
Fix: Fix transparent background of top-right menu

### DIFF
--- a/qa-include/qa-theme-base.php
+++ b/qa-include/qa-theme-base.php
@@ -774,7 +774,7 @@ class qa_html_theme_base
 			if (isset($favorite))
 				$this->output('<form ' . $favorite['form_tags'] . '>');
 
-			$this->output('<div class="qa-main-heading">');
+			$this->output('<div class="qa-main-heading" dir="auto">');
 			$this->favorite();
 			$this->output('<h1>');
 			$this->title();
@@ -1753,7 +1753,7 @@ class qa_html_theme_base
 	public function q_item_title($q_item)
 	{
 		$this->output(
-			'<div class="qa-q-item-title">',
+			'<div class="qa-q-item-title" dir="auto">',
 			'<a href="' . $q_item['url'] . '">' . $q_item['title'] . '</a>',
 			// add closed note in title
 			empty($q_item['closed']['state']) ? '' : ' [' . $q_item['closed']['state'] . ']',
@@ -2238,7 +2238,7 @@ class qa_html_theme_base
 	{
 		$content = isset($q_view['content']) ? $q_view['content'] : '';
 
-		$this->output('<div class="qa-q-view-content qa-post-content">');
+		$this->output('<div class="qa-q-view-content qa-post-content" dir="auto">');
 		$this->output_raw($content);
 		$this->output('</div>');
 	}
@@ -2401,7 +2401,7 @@ class qa_html_theme_base
 			$a_item['content'] = '';
 		}
 
-		$this->output('<div class="qa-a-item-content qa-post-content">');
+		$this->output('<div class="qa-a-item-content qa-post-content" dir="auto">');
 		$this->output_raw($a_item['content']);
 		$this->output('</div>');
 	}

--- a/qa-theme/Candy/qa-styles.css
+++ b/qa-theme/Candy/qa-styles.css
@@ -517,3 +517,7 @@ h2 {font-size:22px; color:#c659ab; padding-top:12px; clear:both;}
 * html .qa-tag-link {background:url(tag-icon-ie6.png) no-repeat left center;}
 * html .qa-a-count {background:url(a-count-icon-ie6.png) no-repeat 32px 13px;}
 * html .qa-favorite-image {background:url(favorite-heart-ie6.png) no-repeat 0 0;}
+
+[dir="auto"] code {
+    float: left;
+}

--- a/qa-theme/Classic/qa-styles.css
+++ b/qa-theme/Classic/qa-styles.css
@@ -474,3 +474,7 @@ h2 {font-size:16px; padding-top:12px; clear:both;}
 	0% { background-color: #ffffaa; }
 	100% { background-color: #fff; }
 }
+
+[dir="auto"] code {
+    float: left;
+}

--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -2650,3 +2650,7 @@ a.qa-browse-cat-link:visited {
 	0% { background-color: #ffffaa; }
 	100% { background-color: #fff; }
 }
+
+[dir="auto"] code {
+    float: left;
+}

--- a/qa-theme/SnowFlat/qa-styles-rtl.css
+++ b/qa-theme/SnowFlat/qa-styles-rtl.css
@@ -449,3 +449,11 @@ h1 {
 .qa-netvote-count-data {
 	direction: ltr;
 }
+
+[dir="auto"] code {
+    float: left;
+}
+
+[dir="rtl"] code {
+    float: left;
+}

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -667,6 +667,7 @@ blockquote p {
 	right: 0;
 	top: 60px;
 	width: 230px;
+	height: 300px;
 	padding: 10px;
 	z-index: 1100;
 }

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -3495,3 +3495,7 @@ input[type="submit"], button {
 .icon-reply:before { content: '\e823'; }
 .icon-power:before { content: '\e824'; }
 .icon-link:before { content: '\e825'; }
+
+[dir="auto"] code {
+    float: left;
+}

--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -345,7 +345,7 @@ class qa_html_theme extends qa_html_theme_base
 			: '<img src="' . $this->rooturl . $this->icon_url . '/closed-q-list.png" class="qam-q-list-close-icon" alt="' . $closedText . '" title="' . $closedText . '"/>';
 
 		$this->output(
-			'<div class="qa-q-item-title">',
+			'<div class="qa-q-item-title" dir="auto">',
 			// add closed note in title
 			$imgHtml,
 			'<a href="' . $q_item['url'] . '">' . $q_item['title'] . '</a>',


### PR DESCRIPTION
# What's wrong?
Using the default theme (*SnowFlat*), the top right menu has a corrupted background, as shown in the image below.  
 
![Screenshot from 2022-10-10 21-14-41](https://user-images.githubusercontent.com/11619295/194925815-54b9d55f-2c69-49a4-b7a4-9154d7a366e2.png)

# What does this PR do?
This PR simply adds extra space for the menu container by extending its height. It will look like this:
![Screenshot from 2022-10-10 21-14-10](https://user-images.githubusercontent.com/11619295/194926073-917e14b3-12a9-4668-990f-a0ec92b545ac.png)

