### PR TITLE
Fix new PHP 8 ValueError exception when there are no user fields

### DIFF
--- a/qa-include/pages/admin/admin-userfields.php
+++ b/qa-include/pages/admin/admin-userfields.php
@@ -153,7 +153,8 @@ if (isset($editfield['position']))
 	$positionvalue = $positionoptions[$editfield['position']];
 else {
 	$positionvalue = isset($previous) ? qa_lang_html_sub('admin/after_x', qa_html(qa_user_userfield_label($previous))) : qa_lang_html('admin/first');
-	$positionoptions[1 + @max(array_keys($positionoptions))] = $positionvalue;
+	$newPosition = empty($positionoptions) ? 1 : max(array_keys($positionoptions)) + 1;
+	$positionoptions[$newPosition] = $positionvalue;
 }
 
 $typeoptions = array(


### PR DESCRIPTION
I'm avoiding the exception in order to get rid of the `@` character and still be backwards compatible.

Reference: https://www.question2answer.org/qa/109931