### PR TITLE
Inscreased HTML wrapper scope by 1, to better handle UI components/Styling

### DIFF
--- a/qa-theme/SnowFlat/qa-theme.php
+++ b/qa-theme/SnowFlat/qa-theme.php
@@ -177,8 +177,6 @@ class qa_html_theme extends qa_html_theme_base
 	public function nav_user_search()
 	{
 		// outputs login form if user not logged in
-		$this->output('<div class="qam-account-items-wrapper">');
-
 		$this->qam_user_account();
 
 		$this->output('<div class="qam-account-items clearfix">');
@@ -204,7 +202,6 @@ class qa_html_theme extends qa_html_theme_base
 
 		$this->nav('user');
 		$this->output('</div> <!-- END qam-account-items -->');
-		$this->output('</div> <!-- END qam-account-items-wrapper -->');
 	}
 
 	/**
@@ -216,7 +213,11 @@ class qa_html_theme extends qa_html_theme_base
 	{
 		$this->output('<div class="qam-main-nav-wrapper clearfix">');
 		$this->output('<div class="sb-toggle-left qam-menu-toggle"><i class="icon-th-list"></i></div>');
-		$this->nav_user_search();
+		
+		$this->output('<div class="qam-account-items-wrapper">');
+			$this->nav_user_search();
+		$this->output('</div>');
+		
 		$this->logo();
 		$this->nav('main');
 		$this->output('</div> <!-- END qam-main-nav-wrapper -->');


### PR DESCRIPTION
Basically just moved `qam-account-items-wrapper` outside `nav_user_search()` , instead of inside.
This gives plugins the ability to output stuff right next to the User Avatar on Modern themes such as SnowFlat.
For example, the OnSiteNotification bell - https://i.ibb.co/9VMxz7z/z317.jpg

```
$this->output('<div class="qam-account-items-wrapper">');
	$this->nav_user_search();
$this->output('</div>');
```