### PR TITLE
Fix for method_exists()

### DIFF
--- a/qa-include/pages/admin/admin-widgets.php
+++ b/qa-include/pages/admin/admin-widgets.php
@@ -195,7 +195,7 @@ $regioncodes = array(
 foreach ($placeoptionhtml as $place => $optionhtml) {
 	$region = $regioncodes[substr($place, 0, 1)];
 
-	$widgetallowed = method_exists($module, 'allow_region') && $module->allow_region($region);
+	$widgetallowed = isset($module) && method_exists($module, 'allow_region') && $module->allow_region($region);
 
 	if ($widgetallowed) {
 		foreach ($widgets as $widget) {


### PR DESCRIPTION
Fix for method_exists()

> `Fatal error: Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in C:\qa\qa-include\pages\admin\admin-widgets.php on line 198`