### PR TITLE
Fix interpretation of plus signs

### DIFF
--- a/.htaccess-example
+++ b/.htaccess-example
@@ -12,5 +12,5 @@ DirectoryIndex index.php
 
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^.*$ index.php?qa-rewrite=$0&%{QUERY_STRING} [L]
+    RewriteRule ^.*$ index.php?qa-rewrite=$0&%{QUERY_STRING} [B,L]
 </IfModule>

--- a/qa-include/qa-index.php
+++ b/qa-include/qa-index.php
@@ -75,8 +75,8 @@ else {
 
 					foreach ($params as $param) {
 						if (preg_match('/^([^\=]*)(\=(.*))?$/', $param, $matches) && isset($matches[3])) {
-							$argument = strtr(rawurldecode($matches[1]), '.', '_'); // simulate PHP's $_GET behavior
-							$_GET[$argument] = qa_string_to_gpc(rawurldecode($matches[3]));
+							$argument = strtr(urldecode($matches[1]), '.', '_'); // simulate PHP's $_GET behavior
+							$_GET[$argument] = qa_string_to_gpc(urldecode($matches[3]));
 						}
 					}
 
@@ -86,10 +86,10 @@ else {
 				// Generally we assume that $_GET['qa-rewrite'] has the right path depth, but this won't be the case if there's
 				// a & or # somewhere in the middle of the path, due to Apache unescaping. So we make a special case for that.
 				// If 'REQUEST_URI' and 'qa-rewrite' already match (as on Nginx), we can skip this.
-				$normalizedpath = rawurldecode($origpath);
+				$normalizedpath = urldecode($origpath);
 				if (substr($normalizedpath, -strlen($qa_rewrite)) !== $qa_rewrite) {
 					$keepparts = count($requestparts);
-					$requestparts = explode('/', rawurldecode($origpath)); // new request calculated from $_SERVER['REQUEST_URI']
+					$requestparts = explode('/', urldecode($origpath)); // new request calculated from $_SERVER['REQUEST_URI']
 
 					// loop forwards so we capture all parts
 					for ($part = 0, $max = count($requestparts); $part < $max; $part++) {
@@ -134,7 +134,7 @@ else {
 					$origpath = substr($origpath, 0, $questionpos);
 				}
 
-				$normalizedpath = rawurldecode($origpath);
+				$normalizedpath = urldecode($origpath);
 				$indexpos = strpos($normalizedpath, $indexpath);
 			}
 


### PR DESCRIPTION
I think a part of a previous [PR](https://github.com/q2a/question2answer/pull/966) should be rolled back.

There are quite a few sources of information and discussion about the plus sign, which is the main difference between the `urlencode` and `rawurlencode` functions, along with their counterparts:

- https://stackoverflow.com/questions/2678551
- https://stackoverflow.com/questions/1634271

However, currently, when trying to search "a b" results in the page heading showing "Search results for a+b". So rethought the whole encoding issue and split the problem in two:

1. Interpreting URLs
2. Generating URLs

At the beginning I thought about following the standard in both cases, but now I think it doesn't make much sense.

1. Approach when interpreting URLs: Even though I don't like it, Q2A needs to process these two URLs as the same valid URL: `https://site.com/user/one+two` and `https://site.com/user/one%20two`. The main issue here becomes forms (as shown in the links above). In short, forms will turn spaces into plus signs by default. So even if it is not following the standard, we need to process them in this way.
Furthermore, `$_GET` superglobal gets their values already processed by `urldecode`.
2. Approach when generating URLs: I don't think there is any need to avoid following a standard when generating URLs.  For example, if there is a space in a query string such as in a user profile, it should turn into a `%20`, rather than a `+`

Turning this into concrete changes, I'd say when creating URLs, we should keep the `rawurlencode` function calls. When interpreting the URLs, which happens in the `index.php` file, we should change the current `rawurldecode` functions to `urldecode`.