### PR TITLE
Make sure there is an editor loaded when reading the content of a post

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -2220,6 +2220,10 @@ function qa_get_post_content($editorfield, $contentfield, &$ineditor, &$inconten
 
 	$ineditor = qa_post_text($editorfield);
 	$editor = qa_load_module('editor', $ineditor);
+	if ($editor === null) {
+		$editor = qa_load_module('editor', '');
+	}
+
 	$readdata = $editor->read_post($contentfield);
 
 	// sanitise 4-byte Unicode


### PR DESCRIPTION
It is possible to send a POST request setting any value to the editor field (e.g. `a_editor`, when submitting an answer).

If the editor is found, it works. If the whole field is removed, it works (by defaulting to the basic editor). If the field is set but the editor is not found, this throws a 500 error.

I think giving the client a basic editor when they attempt to fetch an invalid one seems like an acceptable solution. Catching the error specifically and giving the user the error string seems to be overcomplicated, considering the client is most likely deliberately modifying the HTTP request.