### PR TITLE
Related Question Stats - Sidebar

### DIFF
--- a/qa-include/plugins/qa-widget-related-qs.php
+++ b/qa-include/plugins/qa-widget-related-qs.php
@@ -65,8 +65,12 @@ class qa_related_qs
 			$themeobject->output('<ul class="qa-related-q-list">');
 
 			foreach ($questions as $question) {
+				$isASelected = $question['selchildid'] != null ? ' qa-a-count-selected' : '';
+				$qaLangAnswers = str_replace(':', '', qa_lang_html('profile/answers'));
+				
 				$themeobject->output(
 					'<li class="qa-related-q-item">' .
+					'<span class="qa-related-q-item-stats'. $isASelected .'" title="'.$qaLangAnswers.'">' . qa_html($question['acount']) . '</span>' .
 					'<a href="' . qa_q_path_html($question['postid'], $question['title']) . '">' .
 					qa_html($question['title']) .
 					'</a>' .

--- a/qa-theme/Candy/qa-styles.css
+++ b/qa-theme/Candy/qa-styles.css
@@ -453,7 +453,27 @@ h2 {font-size:22px; color:#c659ab; padding-top:12px; clear:both;}
 .qa-related-qs {font-size:14px;}
 .qa-related-qs h2 {font-size:18px;}
 .qa-related-q-list {list-style-type:none; padding:0;}
-.qa-related-q-item {margin:0.5em 0; word-wrap: break-word;}
+.qa-related-q-item {
+	display: flex;
+	padding: 5px 0;
+	word-wrap: break-word;
+	border-bottom: 1px solid #e0e0e0;
+}
+.qa-related-q-item-stats {
+    flex-shrink: 0;
+	background-color: #ecf0f1;
+    width: 28px;
+    height: 18px;
+    vertical-align: top;
+    text-align: center;
+	margin-top: 2px;
+    margin-inline-end: .6rem;
+    border-radius: 3px;
+}
+.qa-related-q-item .qa-a-count-selected {
+    background-color: #27ae60;
+    color: #fff;
+}
 .qa-activity-count {font-size:14px;}
 .qa-activity-count-item {margin:0.5em 0;}
 .qa-activity-count-data {font-size:24px; font-weight:bold;}

--- a/qa-theme/Classic/qa-styles.css
+++ b/qa-theme/Classic/qa-styles.css
@@ -425,7 +425,27 @@ h2 {font-size:16px; padding-top:12px; clear:both;}
 /* Related questions and activity count widgets */
 
 .qa-related-q-list {list-style-type:none; padding:0;}
-.qa-related-q-item {margin:0.5em 0; word-wrap: break-word;}
+.qa-related-q-item {
+	display: flex;
+	padding: 5px 0;
+	word-wrap: break-word;
+	border-bottom: 1px solid #e0e0e0;
+}
+.qa-related-q-item-stats {
+    flex-shrink: 0;
+	background-color: #ecf0f1;
+    width: 28px;
+    height: 18px;
+    vertical-align: top;
+    text-align: center;
+	margin-top: 2px;
+    margin-inline-end: .6rem;
+    border-radius: 3px;
+}
+.qa-related-q-item .qa-a-count-selected {
+    background-color: #27ae60;
+    color: #fff;
+}
 .qa-activity-count {font-size:150%;}
 .qa-activity-count-item {margin:0.25em 0;}
 .qa-activity-count-data {font-weight:bold;}

--- a/qa-theme/Snow/qa-styles.css
+++ b/qa-theme/Snow/qa-styles.css
@@ -820,7 +820,7 @@ div.header-banner {
 	border: 1px solid #ffd196;
 }
 
-.qa-a-count-selected {
+.qa-a-count-selected, .qa-related-q-item-stats.qa-a-count-selected {
 	background: #d9f5bb;
 	border: 1px solid #c1daa6;
 }
@@ -2307,10 +2307,22 @@ a.qa-browse-cat-link:visited {
 }
 
 .qa-related-q-item {
+	display: flex;
 	margin: 0;
 	padding: 5px 0;
 	border-top: 1px solid #fafafa;
 	border-bottom: 1px solid #ddd;
+}
+.qa-related-q-item-stats {
+    flex-shrink: 0;
+	background-color: #ecf0f1;
+    width: 28px;
+    height: 21px;
+    vertical-align: top;
+    text-align: center;
+	margin-top: 2px;
+    margin-inline-end: .6rem;
+    border-radius: 3px;
 }
 
 .qa-related-q-item:first-child {

--- a/qa-theme/SnowFlat/qa-styles.css
+++ b/qa-theme/SnowFlat/qa-styles.css
@@ -960,8 +960,9 @@ blockquote p {
 	background-color: #e74c3c;
 }
 
-.qa-a-count-selected {
+.qa-a-count-selected, .qa-related-q-item-stats.qa-a-count-selected {
 	background-color: #27ae60;
+	color: #fff;
 }
 
 @media (max-width: 799px) {
@@ -2956,17 +2957,24 @@ input[type="submit"], button {
 	list-style: none;
 }
 
-.qa-related-q-item a {
-	display: block;
+.qa-related-q-item {
+    display: flex;
 	padding: 5px 0;
 	border-bottom: 1px solid #e0e0e0;
 }
-.qa-related-q-item:first-child a {
-	padding-top: 0;
+.qa-related-q-item:last-child {
+	border-bottom: none;
 }
-.qa-related-q-item:last-child a {
-	padding-bottom: 0;
-	border-bottom: 0;
+.qa-related-q-item-stats {
+    flex-shrink: 0;
+	background-color: #ecf0f1;
+    width: 30px;
+    height: 24px;
+    vertical-align: top;
+    text-align: center;
+	margin-top: 2px;
+    margin-inline-end: .6rem;
+    border-radius: 3px;
 }
 
 .qa-nav-cat {


### PR DESCRIPTION
This adds an Answer Counter to the Related Questions widget, on the sidebar. 
Screenshot: https://i.ibb.co/vsYqgtZ/z496.jpg

If people don't want to display stats, they can just comment out the new added line in:
qa-include/plugins/qa-widget-related-qs.php

Line to comment out:
https://github.com/q2a/question2answer/commit/07bcf491e4b125dcc91527813f7b3b3479918fba#diff-49b7248c15fca491a6271afeff134615cc8323afbe63706402ae6369ea32c6adR73