### PR TITLE
Ability to define connection and table creation charset and collation

### DIFF
--- a/qa-config-example.php
+++ b/qa-config-example.php
@@ -49,9 +49,17 @@
 	5. Place all the Question2Answer files on your server.
 	6. Open the appropriate URL, and follow the instructions.
 
-	More detailed installation instructions here: http://www.question2answer.org/
+	More detailed installation instructions here: https://www.question2answer.org
 */
 
+
+/*
+	The QA_MYSQL_CHARSET and QA_MYSQL_COLLATION define the charset and collation used by Q2A to
+	connect to the server, and to create tables and fields.
+*/
+
+	define('QA_MYSQL_CHARSET', 'utf8mb4');
+	define('QA_MYSQL_COLLATION', 'utf8mb4_unicode_ci');
 /*
 	======================================================================
 	 OPTIONAL CONSTANT DEFINITIONS, INCLUDING SUPPORT FOR SINGLE SIGN-ON

--- a/qa-include/db/install.php
+++ b/qa-include/db/install.php
@@ -714,7 +714,7 @@ function qa_db_create_table_sql($rawname, $definition)
 		if (isset($coldef))
 			$querycols .= (strlen($querycols) ? ', ' : '') . (is_int($colname) ? $coldef : ($colname . ' ' . $coldef));
 
-	return 'CREATE TABLE ^' . $rawname . ' (' . $querycols . ') ENGINE=InnoDB CHARSET=utf8';
+	return 'CREATE TABLE ^' . $rawname . ' (' . $querycols . ') ENGINE=InnoDB ' . qa_get_table_charset_collation();
 }
 
 

--- a/qa-include/db/selects.php
+++ b/qa-include/db/selects.php
@@ -1218,7 +1218,7 @@ function qa_db_tag_recent_qs_selectspec($voteuserid, $tag, $start, $full = false
 	$selectspec = qa_db_posts_basic_selectspec($voteuserid, $full);
 
 	// use two tests here - one which can use the index, and the other which narrows it down exactly - then limit to 1 just in case
-	$selectspec['source'] .= " JOIN (SELECT postid FROM ^posttags WHERE wordid=(SELECT wordid FROM ^words WHERE word=$ AND word=$ COLLATE utf8_bin LIMIT 1) ORDER BY postcreated DESC LIMIT #,#) y ON ^posts.postid=y.postid";
+	$selectspec['source'] .= " JOIN (SELECT postid FROM ^posttags WHERE wordid=(SELECT wordid FROM ^words WHERE word=$ AND word=$ LIMIT 1) ORDER BY postcreated DESC LIMIT #,#) y ON ^posts.postid=y.postid";
 	array_push($selectspec['arguments'], $tag, qa_strtolower($tag), $start, $count);
 	$selectspec['sortdesc'] = 'created';
 
@@ -1235,7 +1235,7 @@ function qa_db_tag_word_selectspec($tag)
 {
 	return array(
 		'columns' => array('wordid', 'word', 'tagcount'),
-		'source' => '^words WHERE word=$ AND word=$ COLLATE utf8_bin',
+		'source' => '^words WHERE word=$ AND word=$',
 		'arguments' => array($tag, qa_strtolower($tag)),
 		'single' => true,
 	);

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -313,6 +313,13 @@ function qa_initialize_constants_2()
 		define('QA_FINAL_MYSQL_PORT', QA_MYSQL_PORT);
 	}
 
+	if (!defined('QA_MYSQL_CHARSET')) {
+		define('QA_MYSQL_CHARSET', 'utf8'); // Use hardcoded default until v1.8.8
+	}
+	if (!defined('QA_MYSQL_COLLATION')) {
+		define('QA_MYSQL_COLLATION', null); // Use hardcoded default until v1.8.8
+	}
+
 	// Possible URL schemes for Q2A and the string used for url scheme testing
 
 	define('QA_URL_FORMAT_INDEX', 0);  // http://...../index.php/123/why-is-the-sky-blue

--- a/qa-plugin/event-logger/qa-event-logger.php
+++ b/qa-plugin/event-logger/qa-event-logger.php
@@ -44,7 +44,7 @@ class qa_event_logger
 					'KEY ipaddress (ipaddress),' .
 					'KEY userid (userid),' .
 					'KEY event (event)' .
-					') ENGINE=MyISAM DEFAULT CHARSET=utf8';
+					') ENGINE=MyISAM ' . qa_get_table_charset_collation();
 			} else {
 				// table exists: check it has the correct schema
 				$column = qa_db_read_one_assoc(qa_db_query_sub('SHOW COLUMNS FROM ^eventlog WHERE Field="ipaddress"'));


### PR DESCRIPTION
Given these premises:
 * `utf8` is an alias of `utf8mb3`
 * `utf8mb3` has been deprecated in MySQL 8 and will be removed in future releases
 * `utf8mb4` was introduced in MySQL 5.5 (2010)
 * Currently supported MySQL version is 5.0, according to Q2A documentation
 * There are explicit references to `utf8` charset and `utf8_bin` collation in Q2A

I get to these conclusions:
 * `utf8mb4` should be the default charset to use by Q2A
 * Collations should not be hardcoded in Q2A but rather configured by each user
 * Documentation should be updated to clarify MySQL 5.5 is the minimum supported version

I'm not sure why but there are a few hardcoded collations that are used only when matching tags. This doesn't make much sense on its own, because there wouldn't be any difference between a tag or any other word used in a title or post content. It should be all or none, but not just tags.

Now, between all or none, it should be none. Hardcoding collations would not allow for customization. Whether `papa`, `papá` or `PAPA` should be the same tag or not, or all of them be considered the same when searching, should be up to how the database was setup (with/without accents or with/without case-sensitiveness).

However, Q2A should give the option to allow for this to be configured. `qa-config.php` seems to be the most logical place. This would mainly be relevant during installation time and when the client connects. Changing the charset/collation of a database is a different story and require to change the structure of the database.

Just to close the idea, tables created by plugin developers should have the chance to query the charset and collation as well to create their own tables.

Next steps:
 * Change the last `utf8_bin` column which is `passhash` to `binary`. Clearly, a delicate move: https://github.com/q2a/question2answer/blob/bc1a8bc4fa951da908f14fc15aef65b01e8027a4/qa-include/db/install.php#L110
 * Deprecate function https://github.com/q2a/question2answer/blob/bc1a8bc4fa951da908f14fc15aef65b01e8027a4/qa-include/util/string.php#L602 function and remove their references

The next steps are not taken into account in ths PR as they are waiting for feedback.

Some references to the deprecations in MySQL:

https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8.html#:~:text=utf8%20has%20been%20used%20by%20MySQL%20in%20the%20past%20as%20an%20alias%20for%20the%20utf8mb3%20character%20set%2C%20but%20this%20usage%20is%20now%20deprecated

> utf8 has been used by MySQL in the past as an alias for the utf8mb3 character set, but this usage is now deprecated

https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8mb3.html#:~:text=The%20utf8mb3%20character%20set%20is,lifetimes%20of%20the%20MySQL%208.0.

> The utf8mb3 character set is deprecated. utf8mb3 remains supported for the lifetimes of the MySQL 8.0.x and MySQL 8.4.x LTS release series.
> 
> Expect utf8mb3 to be removed in a future major release of MySQL.

https://dev.mysql.com/blog-archive/mysql-8-0-when-to-use-utf8mb3-over-utf8mb4/#:~:text=MySQL%205.5%20(2010)%20added%20support%20for%20up%20to%204%20byte%20utf8%20using%20the%20new%20utf8mb4%20character%20set.

> MySQL 5.5 (2010) added support for up to 4 byte utf8 using the new utf8mb4 character set.
