### PR TITLE
SEO improvements to avoid URL duplication

### DIFF
--- a/qa-include/app/format.php
+++ b/qa-include/app/format.php
@@ -2220,6 +2220,10 @@ function qa_get_post_content($editorfield, $contentfield, &$ineditor, &$inconten
 
 	$ineditor = qa_post_text($editorfield);
 	$editor = qa_load_module('editor', $ineditor);
+	if ($editor === null) {
+		$editor = qa_load_module('editor', '');
+	}
+
 	$readdata = $editor->read_post($contentfield);
 
 	// sanitise 4-byte Unicode

--- a/qa-include/pages/questions.php
+++ b/qa-include/pages/questions.php
@@ -29,12 +29,16 @@ require_once QA_INCLUDE_DIR . 'app/format.php';
 require_once QA_INCLUDE_DIR . 'app/q-list.php';
 
 $categoryslugs = qa_request_parts(1);
-$countslugs = count($categoryslugs);
+$hasSlugs = !empty($categoryslugs);
+$sort = qa_get('sort');
 
-$sort = ($countslugs && !QA_ALLOW_UNINDEXED_QUERIES) ? null : qa_get('sort');
+if (!QA_ALLOW_UNINDEXED_QUERIES && $hasSlugs) {
+	$getParams = $sort === null ? [] : ['sort' => $sort];
+	qa_redirect('questions', $getParams);
+}
+
 $start = qa_get_start();
 $userid = qa_get_logged_in_userid();
-
 
 // Get list of questions, plus category information
 
@@ -63,21 +67,25 @@ switch ($sort) {
 list($questions, $categories, $categoryid) = qa_db_select_with_pending(
 	qa_db_qs_selectspec($userid, $selectsort, $start, $categoryslugs, null, false, false, qa_opt_if_loaded('page_size_qs')),
 	qa_db_category_nav_selectspec($categoryslugs, false, false, true),
-	$countslugs ? qa_db_slugs_to_category_id_selectspec($categoryslugs) : null
+	$hasSlugs ? qa_db_slugs_to_category_id_selectspec($categoryslugs) : null
 );
 
-if ($countslugs) {
+if ($hasSlugs) {
 	if (!isset($categoryid)) {
 		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
 	}
 
+	if ($categories[$categoryid]['backpath'] !== qa_db_slugs_to_backpath($categoryslugs)) {
+		$expectedPathInUrl = implode('/', array_reverse(explode('/', $categories[$categoryid]['backpath'])));
+		$getParams = $sort === null ? [] : ['sort' => $sort];
+		qa_redirect('questions/' . $expectedPathInUrl, $getParams);
+	}
+
 	$categorytitlehtml = qa_html($categories[$categoryid]['title']);
 	$nonetitle = qa_lang_html_sub('main/no_questions_in_x', $categorytitlehtml);
-
 } else {
 	$nonetitle = qa_lang_html('main/no_questions_found');
 }
-
 
 $categorypathprefix = QA_ALLOW_UNINDEXED_QUERIES ? 'questions/' : null; // this default is applied if sorted not by recent
 $feedpathprefix = null;
@@ -85,30 +93,28 @@ $linkparams = array('sort' => $sort);
 
 switch ($sort) {
 	case 'hot':
-		$sometitle = $countslugs ? qa_lang_html_sub('main/hot_qs_in_x', $categorytitlehtml) : qa_lang_html('main/hot_qs_title');
+		$sometitle = $hasSlugs ? qa_lang_html_sub('main/hot_qs_in_x', $categorytitlehtml) : qa_lang_html('main/hot_qs_title');
 		$feedpathprefix = qa_opt('feed_for_hot') ? 'hot' : null;
 		break;
 
 	case 'votes':
-		$sometitle = $countslugs ? qa_lang_html_sub('main/voted_qs_in_x', $categorytitlehtml) : qa_lang_html('main/voted_qs_title');
+		$sometitle = $hasSlugs ? qa_lang_html_sub('main/voted_qs_in_x', $categorytitlehtml) : qa_lang_html('main/voted_qs_title');
 		break;
 
 	case 'answers':
-		$sometitle = $countslugs ? qa_lang_html_sub('main/answered_qs_in_x', $categorytitlehtml) : qa_lang_html('main/answered_qs_title');
+		$sometitle = $hasSlugs ? qa_lang_html_sub('main/answered_qs_in_x', $categorytitlehtml) : qa_lang_html('main/answered_qs_title');
 		break;
 
 	case 'views':
-		$sometitle = $countslugs ? qa_lang_html_sub('main/viewed_qs_in_x', $categorytitlehtml) : qa_lang_html('main/viewed_qs_title');
+		$sometitle = $hasSlugs ? qa_lang_html_sub('main/viewed_qs_in_x', $categorytitlehtml) : qa_lang_html('main/viewed_qs_title');
 		break;
 
 	default:
 		$linkparams = array();
-		$sometitle = $countslugs ? qa_lang_html_sub('main/recent_qs_in_x', $categorytitlehtml) : qa_lang_html('main/recent_qs_title');
-		$categorypathprefix = 'questions/';
+		$sometitle = $hasSlugs ? qa_lang_html_sub('main/recent_qs_in_x', $categorytitlehtml) : qa_lang_html('main/recent_qs_title');
 		$feedpathprefix = qa_opt('feed_for_questions') ? 'questions' : null;
 		break;
 }
-
 
 // Prepare and return content for theme
 
@@ -116,7 +122,7 @@ $qa_content = qa_q_list_page_content(
 	$questions, // questions
 	qa_opt('page_size_qs'), // questions per page
 	$start, // start offset
-	$countslugs ? $categories[$categoryid]['qcount'] : qa_opt('cache_qcount'), // total count
+	$hasSlugs ? $categories[$categoryid]['qcount'] : qa_opt('cache_qcount'), // total count
 	$sometitle, // title if some questions
 	$nonetitle, // title if no questions
 	$categories, // categories for navigation
@@ -124,14 +130,13 @@ $qa_content = qa_q_list_page_content(
 	true, // show question counts in category navigation
 	$categorypathprefix, // prefix for links in category navigation
 	$feedpathprefix, // prefix for RSS feed paths
-	$countslugs ? qa_html_suggest_qs_tags(qa_using_tags()) : qa_html_suggest_ask($categoryid), // suggest what to do next
+	$hasSlugs ? qa_html_suggest_qs_tags(qa_using_tags()) : qa_html_suggest_ask($categoryid), // suggest what to do next
 	$linkparams, // extra parameters for page links
 	$linkparams // category nav params
 );
 
-if (QA_ALLOW_UNINDEXED_QUERIES || !$countslugs) {
+if (QA_ALLOW_UNINDEXED_QUERIES || !$hasSlugs) {
 	$qa_content['navigation']['sub'] = qa_qs_sub_navigation($sort, $categoryslugs);
 }
-
 
 return $qa_content;

--- a/qa-include/pages/tag.php
+++ b/qa-include/pages/tag.php
@@ -35,7 +35,7 @@ $userid = qa_get_logged_in_userid();
 
 // Find the questions with this tag
 
-if (!strlen((string)$tag)) {
+if ((string)$tag === '') {
 	qa_redirect('tags');
 }
 
@@ -43,6 +43,10 @@ list($questions, $tagword) = qa_db_select_with_pending(
 	qa_db_tag_recent_qs_selectspec($userid, $tag, $start, false, qa_opt_if_loaded('page_size_tag_qs')),
 	qa_db_tag_word_selectspec($tag)
 );
+
+if (isset($tagword['word']) && $tagword['word'] !== $tag) {
+	qa_redirect('tag/' . $tagword['word']);
+}
 
 $pagesize = qa_opt('page_size_tag_qs');
 $questions = array_slice($questions, 0, $pagesize);

--- a/qa-include/pages/user-activity.php
+++ b/qa-include/pages/user-activity.php
@@ -44,9 +44,18 @@ list($useraccount, $questions, $answerqs, $commentqs, $editqs) = qa_db_select_wi
 	qa_db_user_recent_edit_qs_selectspec($loginuserid, $identifier)
 );
 
-if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) // check the user exists
-	return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+if (!QA_FINAL_EXTERNAL_USERS) {
+	if ($useraccount === null) { // check the user exists
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
+	if ($handle !== $useraccount['handle']) {
+		qa_redirect('user/' . $useraccount['handle'] . '/activity');
+	}
+}
 
+if ($handle !== $useraccount['handle']) {
+	qa_redirect('user/' . $useraccount['handle'] . '/activity');
+}
 
 // Get information on user references
 

--- a/qa-include/pages/user-answers.php
+++ b/qa-include/pages/user-answers.php
@@ -44,9 +44,14 @@ list($useraccount, $userpoints, $questions) = qa_db_select_with_pending(
 	qa_db_user_recent_a_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_activity'), $start)
 );
 
-if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) // check the user exists
-	return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
-
+if (!QA_FINAL_EXTERNAL_USERS) {
+	if ($useraccount === null) { // check the user exists
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
+	if ($handle !== $useraccount['handle']) {
+		qa_redirect('user/' . $useraccount['handle'] . '/answers');
+	}
+}
 
 // Get information on user questions
 

--- a/qa-include/pages/user-profile.php
+++ b/qa-include/pages/user-profile.php
@@ -51,6 +51,9 @@ if (!QA_FINAL_EXTERNAL_USERS) {
 	}
 
 	$userid = $useraccount['userid'];
+	if ($handle !== $useraccount['handle']) {
+		qa_redirect('user/' . $useraccount['handle']);
+	}
 }
 
 list($userprofile, $userfields, $usermessages, $userpoints, $userlevels, $navcategories, $userrank) =

--- a/qa-include/pages/user-questions.php
+++ b/qa-include/pages/user-questions.php
@@ -44,9 +44,14 @@ list($useraccount, $userpoints, $questions) = qa_db_select_with_pending(
 	qa_db_user_recent_qs_selectspec($loginuserid, $identifier, qa_opt_if_loaded('page_size_qs'), $start)
 );
 
-if (!QA_FINAL_EXTERNAL_USERS && !is_array($useraccount)) // check the user exists
-	return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
-
+if (!QA_FINAL_EXTERNAL_USERS) {
+	if ($useraccount === null) { // check the user exists
+		return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+	}
+	if ($handle !== $useraccount['handle']) {
+		qa_redirect('user/' . $useraccount['handle'] . '/questions');
+	}
+}
 
 // Get information on user questions
 

--- a/qa-include/pages/user-wall.php
+++ b/qa-include/pages/user-wall.php
@@ -36,7 +36,6 @@ if (QA_FINAL_EXTERNAL_USERS) {
 	qa_exit();
 }
 
-
 // $handle, $userhtml are already set by /qa-include/page/user.php
 
 $start = qa_get_start();
@@ -49,9 +48,12 @@ list($useraccount, $usermessages) = qa_db_select_with_pending(
 	qa_db_recent_messages_selectspec(null, null, $handle, false, qa_opt_if_loaded('page_size_wall'), $start)
 );
 
-if (!is_array($useraccount)) // check the user exists
+if ($useraccount === null) // check the user exists
 	return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
 
+if ($handle !== $useraccount['handle']) {
+	qa_redirect('user/' . $useraccount['handle'] . '/wall');
+}
 
 // Perform pagination
 

--- a/qa-include/qa-base.php
+++ b/qa-include/qa-base.php
@@ -1803,17 +1803,17 @@ function qa_redirect($request, $params = null, $rooturl = null, $neaturls = null
 	qa_redirect_raw(qa_path($request, $params, $rooturl, $neaturls, $anchor));
 }
 
-
 /**
  * Redirect the user's web browser to page $path which is already a URL
- * @param $url
+ * @param string $url
+ * @param int $statusCode
  * @return mixed
  */
-function qa_redirect_raw($url)
+function qa_redirect_raw($url, $statusCode = 301)
 {
 	if (qa_to_override(__FUNCTION__)) { $args=func_get_args(); return qa_call_override(__FUNCTION__, $args); }
 
-	header('Location: ' . $url);
+	header('Location: ' . $url, true, $statusCode);
 	qa_exit('redirect');
 }
 


### PR DESCRIPTION
Should avoid issues like these matching URLs:
https://www.question2answer.org/qa/user/pupi1985
https://www.question2answer.org/qa/user/Pupi1985

Also works with tags, unanswered questions, questions page, hot page.

Also turns 302 redirects to 301 redirects, so that search engines stop looking for the incorrect URL.